### PR TITLE
Enhance the web application into using MongoDB as a persistence layer

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,6 @@
+MONGO_HOST=
+# MONGO_PORT=27017
+MONGO_AUTHENTICATION_DATABASE=  # Set this equal to `admin` (without the backticks), as per https://hub.docker.com/_/mongo.
+MONGO_USERNAME=  # As configuration for a user that will be created in MongoDB's "authentication database" called `admin`, set a username for said user.
+MONGO_PASSWORD=  # As configuration for a user that will be created in MongoDB's "authentication database" called `admin`, set a password for said user.
+MONGO_DATABASE=  # Set this equal to `db-4-m-j-3` (without the backticks). Full disclosure: that is _my_ recommendation. For more details on what this variable does when the MongoDB container is created: see https://hub.docker.com/_/mongo

--- a/.env.template
+++ b/.env.template
@@ -3,4 +3,4 @@ MONGO_HOST=
 MONGO_AUTHENTICATION_DATABASE=  # Set this equal to `admin` (without the backticks), as per https://hub.docker.com/_/mongo.
 MONGO_USERNAME=  # As configuration for a user that will be created in MongoDB's "authentication database" called `admin`, set a username for said user.
 MONGO_PASSWORD=  # As configuration for a user that will be created in MongoDB's "authentication database" called `admin`, set a password for said user.
-MONGO_DATABASE=  # Set this equal to `db-4-m-j-3` (without the backticks). Full disclosure: that is _my_ recommendation. For more details on what this variable does when the MongoDB container is created: see https://hub.docker.com/_/mongo
+MONGO_DATABASE=  # Set this equal to `db-4-m-j-3` (without the backticks). Full disclosure: that is _my_ recommendation. For more details on what this variable does when the MongoDB container is created, see https://hub.docker.com/_/mongo

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dist
 .pnp.*
 
 scratch-pad.md
+
+jest.config.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,15 +2,24 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Node Backend",
       "type": "node",
       "request": "launch",
-      "name": "Backend app",
       "skipFiles": ["<node_internals>/**"],
-      "program": "${workspaceFolder}/src/server.js",
+      "console": "integratedTerminal",
       "env": {
         "NODE_ENV": "development"
       },
-      "console": "integratedTerminal"
+      "program": "${workspaceFolder}/src/server.js"
+    },
+    {
+      "name": "Nodemon Backend",
+      "type": "node",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66c072f415df7b3e99c5de5d",
-   "createdAt" : "2024-08-17T09:52:52.305Z",
+   "_id" : "66c2dbf2d0d5b26a9bdfbc9f",
+   "createdAt" : "2024-08-19T05:45:22.243Z",
    "deadline" : "2024-08-19T09:00:00.000Z",
    "description" : "containerize the backend",
    "epic" : "backend",
@@ -271,8 +271,27 @@ curl -v \
 ```
 
 ```bash
+export ISSUE_1_ID=<the-_id-present-in-the-preceding-HTTP-response>
+
+export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_1_ID-but-with-the-last-character-changed-to-something-else>
+```
+
+```bash
 curl -v \
   localhost:5000/api/v1/issues/17 \
+  | json_pp
+
+# ...
+< HTTP/1.1 400 Bad Request
+# ...
+{
+   "message" : "Invalid ID provided"
+}
+
+
+
+curl -v \
+  localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
   | json_pp
 
 # ...
@@ -284,21 +303,22 @@ curl -v \
 
 
 
+
 curl -v \
-  localhost:5000/api/v1/issues/1 \
+  localhost:5000/api/v1/issues/${ISSUE_1_ID} \
   | json_pp
 
 # ...
 < HTTP/1.1 200 OK
 # ...
 {
-   "createdAt" : null,
-   "deadline" : null,
-   "description" : "build a backend application using Express (without a persistence layer)",
+   "__v" : 0,
+   "_id" : "66c2dbf2d0d5b26a9bdfbc9f",
+   "createdAt" : "2024-08-19T05:45:22.243Z",
+   "deadline" : "2024-08-19T09:00:00.000Z",
+   "description" : "containerize the backend",
    "epic" : "backend",
-   "finishedAt" : null,
-   "id" : 1,
-   "status" : "3 = in progress"
+   "status" : "1 = backlog"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ then you can go on to
 launch another terminal window and,
 in it, issue the following requests to the HTTP server:
 
+<u>TODO: (2024/08/20, 22:55)</u> re-arrange the example requests in the following order: POST, GET, GET /:id, PUT /:id, DELETE /:id + do the same for the request handlers and the tests
 ```bash
 curl -v \
   localhost:5000/api/v1/issues \
@@ -193,31 +194,13 @@ curl -v \
 {
    "resources" : [
       {
-         "createdAt" : null,
-         "deadline" : null,
-         "description" : "build a backend application using Express (without a persistence layer)",
+         "__v" : 0,
+         "_id" : "66c4f458e3788fc8e79d0c89",
+         "createdAt" : "2024-08-20T19:54:00.804Z",
+         "deadline" : "2024-08-19T09:00:00.000Z",
+         "description" : "containerize the backend",
          "epic" : "backend",
-         "finishedAt" : null,
-         "id" : 1,
-         "status" : "3 = in progress"
-      },
-      {
-         "createdAt" : null,
-         "deadline" : null,
-         "description" : "make it possible to use VS Code to serve the backend",
-         "epic" : "ease of development",
-         "finishedAt" : null,
-         "id" : 2,
-         "status" : "1 = backlog"
-      },
-      {
-         "createdAt" : null,
-         "deadline" : null,
-         "description" : "implement a persistence layer using MongoDB",
-         "epic" : "backend",
-         "finishedAt" : null,
-         "id" : 3,
-         "status" : "1 = backlog"
+         "status" : "4 = done"
       }
    ]
 }

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ curl -v \
 ```bash
 export ISSUE_1_ID=<the-_id-present-in-the-preceding-HTTP-response>
 
-export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_1_ID-but-with-the-last-character-changed-to-something-else>
+export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_1_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ run automated tests
       mongo:latest
    ```
 
+   <u>TODO: (2024/08/17, 11:00)</u> as of the commit that adds this line, the preceding command creates "a simple user with the role `root⁠` in the `admin` authentication database⁠" (cf. https://hub.docker.com/_/mongo ); investigate (a) what "creation scripts in /docker-entrypoint-initdb.d/*.js" (cf. ) would need to be created and (b) how the preceding commands would need to be changed _in order for_ a non-`root` user to be created (cf. https://www.mongodb.com/docs/manual/core/security-users/#user-authentication-database )
+
 [step 5]
 
 start a process responsible for serving the application instance

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ curl -v \
   -H "Content-Type: application/json" \
   -d "{
          \"status\": \"1 = backlog\",
+         \"deadline\": \"2024-08-19T09:00:00.000Z\",
          \"epic\": \"backend\",
          \"description\": \"containerize the backend\"
     }" \
@@ -206,12 +207,12 @@ curl -v \
 < HTTP/1.1 201 Created
 # ...
 {
-   "createdAt" : null,
-   "deadline" : null,
+   "__v" : 0,
+   "_id" : "66c072f415df7b3e99c5de5d",
+   "createdAt" : "2024-08-17T09:52:52.305Z",
+   "deadline" : "2024-08-19T09:00:00.000Z",
    "description" : "containerize the backend",
    "epic" : "backend",
-   "finishedAt" : null,
-   "id" : 4,
    "status" : "1 = backlog"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,59 @@ npm install
 
 run automated tests
 
+> recall that:
+>
+>  - The `mongodb-memory-server` package is a Node.js library
+>    used for testing MongoDB interactions
+>    without requiring a running MongoDB instance.
+>
+>  - It typically downloads and runs a local, temporary MongoDB server
+>    for the duration of your tests.
+>
+> at the time of writing (i.e. as of 2024/08/25):
+>
+>  - the `mongodb-memory-server` package specifically requires OpenSSL 1.1
+>
+>  - if you run the automated tests on a Fedora 40 operating system,
+>    that will fail
+>    (because Fedora 40 has a different version of OpenSSL installed)
+>
+>  - the preceding 2 bulletpoints are a «TLDR version» of [this comment](https://github.com/kaloyan-marinov/mini-jira-3/commit/989785eb272e72fb4bc7d44d70e761ac7a2812d9#commitcomment-145809410)
+>
+>  - if your operating system is Fedora 40,
+>    it is possible to get the automated tests to pass
+>    **_by influencing which OpenSSL version the MongoDB binary uses at runtime_**:
+>    **_(without altering/modifying the core libraries in the host system)_**:
+>     - install [Miniconda](https://docs.anaconda.com/miniconda/miniconda-install/)
+>     - create a Conda environment that contains OpenSSL 1.1:
+>        ```bash
+>        $ conda create \
+>           --name=python-3-11-plus-openssl-1-1 \
+>           --python=3.11 \
+>           --openssl=1.1
+>        ```
+>     - verify that the preceding step worked as desired:
+>        ```bash
+>        $ conda activate python-3-11-plus-openssl-1-1
+>
+>        (python-3-11-plus-openssl-1-1) $ echo ${CONDA_PREFIX}
+>        ~/miniconda3/envs/python-3-11-plus-openssl-1-1
+>        (python-3-11-plus-openssl-1-1) $ which openssl
+>        ~/miniconda3/envs/python-3-11-plus-openssl-1-1/bin/openssl
+>        (python-3-11-plus-openssl-1-1) $ openssl version
+>        OpenSSL 1.1.1w  11 Sep 2023
+>
+>        (python-3-11-plus-openssl-1-1) $ conda deactivate
+>        ```
+>
+>     - ensure that each of the following bulletpoints is followed from within a terminal session,
+>       which has an environment variable called `LD_LIBRARY_PATH`,
+>       with that environment variable holding the value of `${CONDA_PREFIX}/lib` -
+>       one way of ensuring that is to create a file called `jest.config.js`
+>       and make it consist of the following single statement:
+>
+>       `process.env.LD_LIBRARY_PATH = '<the-value-of-${CONDA_PREFIX}/lib>';`;
+
 - to run all of the project's suite of automated tests <u>in regular mode</u>,
   issue the following command:
 
@@ -186,7 +239,7 @@ curl -v \
 < HTTP/1.1 400 Bad Request
 # ...
 {
-   "message" : "Each of 'status', 'description' must be specified in the HTTP request's body"
+   "message" : "Unable to create a new issue."
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ create an empty database:
       --name container-m-j-3-mongo \
       --mount source=volume-m-j-3-mongo,destination=/data/db \
       --env MONGO_INITDB_ROOT_USERNAME=$(grep -oP '^MONGO_USERNAME=\K.*' .env) \
-	   --env MONGO_INITDB_ROOT_PASSWORD=$(grep -oP '^MONGO_PASSWORD=\K.*' .env) \
+      --env MONGO_INITDB_ROOT_PASSWORD=$(grep -oP '^MONGO_PASSWORD=\K.*' .env) \
       --env MONGO_INITDB_DATABASE=$(grep -oP '^MONGO_DATABASE=\K.*' .env) \
       --publish 27017:27017 \
       mongo:latest

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ which is a pared-down version of [Jira](
 
 [step 1]
 
+create `.env` file within your local repository by taking the following steps:
+
+   ```bash
+   $ cp \
+      .env.template \
+      .env
+
+   # Edit the content of the created file as per the comments/instructions therein.
+   ```
+
+[step 2]
+
 install the package dependencies
 by issuing the following command:
 
@@ -16,7 +28,7 @@ by issuing the following command:
 npm install
 ```
 
-[step 2]
+[step 3]
 
 run automated tests
 
@@ -49,7 +61,7 @@ run automated tests
       --watchAll
    ```
 
-[step 3]
+[step 4]
 
 - create an empty database:
 
@@ -58,18 +70,14 @@ run automated tests
       --name container-m-j-3-mongo \
       --add-host host.docker.internal:host-gateway \
       --mount source=volume-m-j-3-mongo,destination=/data/db \
-      --env MONGO_INITDB_ROOT_USERNAME=mongoadmin \
-	   --env MONGO_INITDB_ROOT_PASSWORD=secret \
-      --env MONGO_INITDB_DATABASE=db-mini-jira-3 \
+      --env MONGO_INITDB_ROOT_USERNAME=$(grep -oP '^MONGO_USERNAME=\K.*' .env) \
+	   --env MONGO_INITDB_ROOT_PASSWORD=$(grep -oP '^MONGO_PASSWORD=\K.*' .env) \
+      --env MONGO_INITDB_DATABASE=$(grep -oP '^MONGO_DATABASE=\K.*' .env) \
       --publish 27017:27017 \
       mongo:latest
    ```
 
-   `--env MONGO_INITDB_DATABASE=<...>`
-
-   `--env-file backend/.env \`
-
-[step 4]
+[step 5]
 
 start a process responsible for serving the application instance
 
@@ -86,7 +94,7 @@ start a process responsible for serving the application instance
 > it serves the application in debug mode
 > (i.e. it allows you to set breakpoints).
 
-[step 5]
+[step 6]
 
 if you have performed the preceding step successfully,
 then you can go on to

--- a/README.md
+++ b/README.md
@@ -182,30 +182,6 @@ then you can go on to
 launch another terminal window and,
 in it, issue the following requests to the HTTP server:
 
-<u>TODO: (2024/08/20, 22:55)</u> re-arrange the example requests in the following order: POST, GET, GET /:id, PUT /:id, DELETE /:id + do the same for the request handlers and the tests
-```bash
-curl -v \
-  localhost:5000/api/v1/issues \
-  | json_pp
-
-# ...
-< HTTP/1.1 200 OK
-# ...
-{
-   "resources" : [
-      {
-         "__v" : 0,
-         "_id" : "66c4f458e3788fc8e79d0c89",
-         "createdAt" : "2024-08-20T19:54:00.804Z",
-         "deadline" : "2024-08-19T09:00:00.000Z",
-         "description" : "containerize the backend",
-         "epic" : "backend",
-         "status" : "4 = done"
-      }
-   ]
-}
-```
-
 
 
 ```bash
@@ -259,6 +235,33 @@ export ISSUE_1_ID=<the-_id-present-in-the-preceding-HTTP-response>
 export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_1_ID-but-with-the-last-character-changed-to-something-else>
 ```
 
+
+
+```bash
+curl -v \
+  localhost:5000/api/v1/issues \
+  | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66c4f458e3788fc8e79d0c89",
+         "createdAt" : "2024-08-20T19:54:00.804Z",
+         "deadline" : "2024-08-19T09:00:00.000Z",
+         "description" : "containerize the backend",
+         "epic" : "backend",
+         "status" : "4 = done"
+      }
+   ]
+}
+```
+
+
+
 ```bash
 curl -v \
   localhost:5000/api/v1/issues/17 \
@@ -270,9 +273,9 @@ curl -v \
 {
    "message" : "Invalid ID provided"
 }
+```
 
-
-
+```bash
 curl -v \
   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
   | json_pp
@@ -283,10 +286,9 @@ curl -v \
 {
    "message" : "Resource not found"
 }
+```
 
-
-
-
+```bash
 curl -v \
   localhost:5000/api/v1/issues/${ISSUE_1_ID} \
   | json_pp
@@ -306,6 +308,7 @@ curl -v \
 ```
 
 
+
 ```bash
 curl -v \
   -X PUT \
@@ -332,6 +335,7 @@ curl -v \
 {
    "message" : "Resource not found"
 }
+```
 
 ```bash
 curl -v \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ run automated tests
 
 [step 3]
 
+- create an empty database:
+
+   ```bash
+   docker run \
+      --name container-m-j-3-mongo \
+      --add-host host.docker.internal:host-gateway \
+      --mount source=volume-m-j-3-mongo,destination=/data/db \
+      --env MONGO_INITDB_ROOT_USERNAME=mongoadmin \
+	   --env MONGO_INITDB_ROOT_PASSWORD=secret \
+      --env MONGO_INITDB_DATABASE=db-mini-jira-3 \
+      --publish 27017:27017 \
+      mongo:latest
+   ```
+
+   `--env MONGO_INITDB_DATABASE=<...>`
+
+   `--env-file backend/.env \`
+
+[step 4]
+
 start a process responsible for serving the application instance
 
 - to do that <u>in regular mode</u>,
@@ -66,7 +86,7 @@ start a process responsible for serving the application instance
 > it serves the application in debug mode
 > (i.e. it allows you to set breakpoints).
 
-[step 4]
+[step 5]
 
 if you have performed the preceding step successfully,
 then you can go on to

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ npm install
 
 run automated tests
 
+> <u>This note is important only if your operating system is Fedora 40.</u>
+>
 > recall that:
 >
 >  - The `mongodb-memory-server` package is a Node.js library
@@ -55,7 +57,9 @@ run automated tests
 >    it is possible to get the automated tests to pass
 >    **_by influencing which OpenSSL version the MongoDB binary uses at runtime_**:
 >    **_(without altering/modifying the core libraries in the host system)_**:
+>
 >     - install [Miniconda](https://docs.anaconda.com/miniconda/miniconda-install/)
+>
 >     - create a Conda environment that contains OpenSSL 1.1:
 >        ```bash
 >        $ conda create \
@@ -63,6 +67,7 @@ run automated tests
 >           --python=3.11 \
 >           --openssl=1.1
 >        ```
+>
 >     - verify that the preceding step worked as desired:
 >        ```bash
 >        $ conda activate python-3-11-plus-openssl-1-1

--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ run automated tests
 
 [step 4]
 
-- create an empty database:
+create an empty database:
+
+- run a containerized MongoDB server
 
    ```bash
    docker run \
       --name container-m-j-3-mongo \
-      --add-host host.docker.internal:host-gateway \
       --mount source=volume-m-j-3-mongo,destination=/data/db \
       --env MONGO_INITDB_ROOT_USERNAME=$(grep -oP '^MONGO_USERNAME=\K.*' .env) \
 	   --env MONGO_INITDB_ROOT_PASSWORD=$(grep -oP '^MONGO_PASSWORD=\K.*' .env) \
@@ -78,6 +79,31 @@ run automated tests
    ```
 
    <u>TODO: (2024/08/17, 11:00)</u> as of the commit that adds this line, the preceding command creates "a simple user with the role `root⁠` in the `admin` authentication database⁠" (cf. https://hub.docker.com/_/mongo ); investigate (a) what "creation scripts in /docker-entrypoint-initdb.d/*.js" (cf. ) would need to be created and (b) how the preceding commands would need to be changed _in order for_ a non-`root` user to be created (cf. https://www.mongodb.com/docs/manual/core/security-users/#user-authentication-database )
+
+- optionally, connect to the MongoDB server
+  by means of the `mongosh` command-line client
+
+   ```bash
+   docker container inspect container-m-j-3-mongo \
+      | grep IPAddress
+   ```
+
+   ```bash
+   export CONTAINER_M_J_3_MONGO_IP=<the-value-returned-by-the-preceding-command>
+   ```
+
+   ```bash
+   docker run \
+      -it \
+      --rm \
+      mongo:latest \
+         mongosh \
+         --host ${CONTAINER_M_J_3_MONGO_IP} \
+         --username $(grep -oP '^MONGO_USERNAME=\K.*' .env) \
+         --password $(grep -oP '^MONGO_PASSWORD=\K.*' .env) \
+         --authenticationDatabase admin \
+         $(grep -oP '^MONGO_DATABASE=\K.*' .env)
+   ```
 
 [step 5]
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ curl -v \
          "epic" : "ease of development",
          "finishedAt" : null,
          "id" : 2,
-         "status" : "1 = in backlog"
+         "status" : "1 = backlog"
       },
       {
          "createdAt" : null,
@@ -138,7 +138,7 @@ curl -v \
          "epic" : "backend",
          "finishedAt" : null,
          "id" : 3,
-         "status" : "1 = in backlog"
+         "status" : "1 = backlog"
       }
    ]
 }
@@ -151,7 +151,7 @@ curl -v \
   -X POST \
   -H "Content-Type: application/json" \
   -d "{
-         \"status\": \"1 = in backlog\"
+         \"status\": \"1 = backlog\"
     }" \
   localhost:5000/api/v1/issues \
   | json_pp
@@ -169,7 +169,7 @@ curl -v \
   -X POST \
   -H "Content-Type: application/json" \
   -d "{
-         \"status\": \"1 = in backlog\",
+         \"status\": \"1 = backlog\",
          \"epic\": \"backend\",
          \"description\": \"containerize the backend\"
     }" \
@@ -186,7 +186,7 @@ curl -v \
    "epic" : "backend",
    "finishedAt" : null,
    "id" : 4,
-   "status" : "1 = in backlog"
+   "status" : "1 = backlog"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ run automated tests
 >
 >  - if your operating system is Fedora 40,
 >    it is possible to get the automated tests to pass
->    **_by influencing which OpenSSL version the MongoDB binary uses at runtime_**:
+>    **_by influencing which OpenSSL version the MongoDB binary uses at runtime_**
 >    **_(without altering/modifying the core libraries in the host system)_**:
 >
 >     - install [Miniconda](https://docs.anaconda.com/miniconda/miniconda-install/)

--- a/README.md
+++ b/README.md
@@ -357,10 +357,26 @@ curl -v \
 }
 ```
 
+
+
 ```bash
 curl -v \
   -X DELETE \
   localhost:5000/api/v1/issues/17 \
+  | json_pp
+
+# ...
+< HTTP/1.1 400 Bad Request
+# ...
+{
+   "message" : "Invalid ID provided"
+}
+```
+
+```bash
+curl -v \
+  -X DELETE \
+  localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
   | json_pp
 
 # ...
@@ -374,7 +390,7 @@ curl -v \
 ```bash
 curl -v \
   -X DELETE \
-  localhost:5000/api/v1/issues/1
+  localhost:5000/api/v1/issues/${ISSUE_1_ID}
 
 # ...
 < HTTP/1.1 204 No Content

--- a/README.md
+++ b/README.md
@@ -330,26 +330,25 @@ curl -v \
   | json_pp
 
 # ...
-< HTTP/1.1 404 Not Found
+< HTTP/1.1 400 Bad Request
 # ...
 {
-   "message" : "Resource not found"
+   "message" : "Invalid ID provided"
 }
 ```
 
 ```bash
 curl -v \
   -X PUT \
-  localhost:5000/api/v1/issues/1 \
+  localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
   | json_pp
 
 # ...
-< HTTP/1.1 400 Bad Request
+< HTTP/1.1 404 Not Found
 # ...
 {
-   "message" : "At least one of 'status', 'epic', 'description' is missing from the HTTP request's body"
+   "message" : "Resource not found"
 }
-```
 
 ```bash
 curl -v \
@@ -358,19 +357,19 @@ curl -v \
   -d "{
          \"status\": \"4 = done\"
     }" \
-  localhost:5000/api/v1/issues/1 \
+  localhost:5000/api/v1/issues/${ISSUE_1_ID} \
   | json_pp
 
 # ...
 < HTTP/1.1 200 OK
 # ...
 {
-   "createdAt" : null,
-   "deadline" : null,
-   "description" : "build a backend application using Express (without a persistence layer)",
+   "__v" : 0,
+   "_id" : "66c4f458e3788fc8e79d0c89",
+   "createdAt" : "2024-08-20T19:54:00.804Z",
+   "deadline" : "2024-08-19T09:00:00.000Z",
+   "description" : "containerize the backend",
    "epic" : "backend",
-   "finishedAt" : null,
-   "id" : 1,
    "status" : "4 = done"
 }
 ```

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -56,7 +56,7 @@ describe('GET /api/v1/issues/:id', () => {
 });
 
 describe('POST /api/v1/issues', () => {
-  xtest('if "status" is missing, should return 400', async () => {
+  test('if "status" is missing, should return 400', async () => {
     // Act.
     const response = await request(app).post('/api/v1/issues').send({
       description: 'containerize the backend',
@@ -65,12 +65,11 @@ describe('POST /api/v1/issues', () => {
     // Assert.
     expect(response.status).toEqual(400);
     expect(response.body).toEqual({
-      message:
-        "Each of 'status', 'description' must be specified in the HTTP request's body",
+      message: 'Unable to create a new issue.',
     });
   });
 
-  xtest('if "description" is missing, should return 400', async () => {
+  test('if "description" is missing, should return 400', async () => {
     // Act.
     const response = await request(app).post('/api/v1/issues').send({
       status: '1 = backlog',
@@ -79,8 +78,7 @@ describe('POST /api/v1/issues', () => {
     // Assert.
     expect(response.status).toEqual(400);
     expect(response.body).toEqual({
-      message:
-        "Each of 'status', 'description' must be specified in the HTTP request's body",
+      message: 'Unable to create a new issue.',
     });
   });
 

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -26,7 +26,7 @@ afterAll(async () => {
 });
 
 // TODO: (2024/08/25, 23:12)
-//       re-arrange the groups of automated tests example requests
+//       re-arrange the groups of automated tests
 //       to match the order in `README.md` and in `src/app.js`
 
 describe('GET /api/v1/issues/:id', () => {

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -25,6 +25,10 @@ afterAll(async () => {
   await mongoMemoryServer.stop();
 });
 
+// TODO: (2024/08/25, 23:12)
+//       re-arrange the groups of automated tests example requests
+//       to match the order in `README.md` and in `src/app.js`
+
 describe('GET /api/v1/issues/:id', () => {
   test('if an invalid ID is provided, should return 400', async () => {
     // Act.

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -51,7 +51,7 @@ describe('POST /api/v1/issues', () => {
   test('if "description" is missing, should return 400', async () => {
     // Act.
     const response = await request(app).post('/api/v1/issues').send({
-      status: '1 = in backlog',
+      status: '1 = backlog',
     });
 
     // Assert.
@@ -65,7 +65,7 @@ describe('POST /api/v1/issues', () => {
   xtest('if "status" and "description", should return 201', async () => {
     // Act.
     const response = await request(app).post('/api/v1/issues').send({
-      status: '1 = in backlog',
+      status: '1 = backlog',
       description: 'containerize the backend',
     });
 
@@ -74,7 +74,7 @@ describe('POST /api/v1/issues', () => {
     expect(response.body).toEqual({
       id: 4,
       createdAt: null,
-      status: '1 = in backlog',
+      status: '1 = backlog',
       deadline: null,
       finishedAt: null,
       description: 'containerize the backend',

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -26,7 +26,7 @@ afterAll(async () => {
 });
 
 describe('GET /api/v1/issues/:id', () => {
-  test('if ID does not exist, should return 404', async () => {
+  test('if an invalid ID is provided, should return 400', async () => {
     // Act.
     const response = await request(app).get('/api/v1/issues/17');
 
@@ -119,7 +119,7 @@ describe('POST /api/v1/issues', () => {
 });
 
 describe('PUT /api/v1/issues/:id', () => {
-  test('if a invalid ID is provided, should return 400', async () => {
+  test('if an invalid ID is provided, should return 400', async () => {
     // Arrange.
     const issue = await Issue.create({
       status: '1 = backlog',

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -226,22 +226,24 @@ describe('GET /api/v1/issues', () => {
     // Assert.
     expect(response.status).toEqual(200);
 
-    // TODO: (2024/08/20, 23:20) make this test lighter on manipulation/logic + easier to just read and understand
-    const issue1JSON = issue1.toJSON();
-    const issue2JSON = issue2.toJSON();
     expect(response.body).toEqual({
       resources: [
         {
-          ...issue1JSON,
-          _id: issue1JSON._id.toString(),
-          deadline: issue1JSON.deadline.toISOString(),
-          createdAt: issue1JSON.createdAt.toISOString(),
+          __v: expect.anything(),
+          _id: issue1._id.toString(),
+          createdAt: expect.anything(),
+          status: '3 = in progress',
+          deadline: '2024-08-20T21:07:45.759Z',
+          description: 'write tests for the other request-handling functions',
         },
         {
-          ...issue2JSON,
-          _id: issue2JSON._id.toString(),
-          deadline: issue2JSON.deadline.toISOString(),
-          createdAt: issue2JSON.createdAt.toISOString(),
+          __v: expect.anything(),
+          _id: issue2._id.toString(),
+          createdAt: expect.anything(),
+          status: '1 = backlog',
+          deadline: '2024-08-20T21:08:31.345Z',
+          description:
+            'switch from `const express = require(express)` to `import express from "express";"',
         },
       ],
     });

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -192,3 +192,58 @@ describe('PUT /api/v1/issues/:id', () => {
     });
   });
 });
+
+describe('GET /api/v1/issues', () => {
+  test('if there are no Issue resources in the MongoDB server, should return 200 and an empty list', async () => {
+    // Act.
+    const response = await request(app).get('/api/v1/issues');
+
+    // Assert.
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      resources: [],
+    });
+  });
+
+  test('if there are Issue resources, should return 200 and representations of the resources', async () => {
+    // Arrange.
+    const issue1 = await Issue.create({
+      status: '3 = in progress',
+      deadline: new Date('2024-08-20T21:07:45.759Z'),
+      description: 'write tests for the other request-handling functions',
+    });
+
+    const issue2 = await Issue.create({
+      status: '1 = backlog',
+      deadline: new Date('2024-08-20T21:08:31.345Z'),
+      description:
+        'switch from `const express = require(express)` to `import express from "express";"',
+    });
+
+    // Act.
+    const response = await request(app).get('/api/v1/issues');
+
+    // Assert.
+    expect(response.status).toEqual(200);
+
+    // TODO: (2024/08/20, 23:20) make this test lighter on manipulation/logic + easier to just read and understand
+    const issue1JSON = issue1.toJSON();
+    const issue2JSON = issue2.toJSON();
+    expect(response.body).toEqual({
+      resources: [
+        {
+          ...issue1JSON,
+          _id: issue1JSON._id.toString(),
+          deadline: issue1JSON.deadline.toISOString(),
+          createdAt: issue1JSON.createdAt.toISOString(),
+        },
+        {
+          ...issue2JSON,
+          _id: issue2JSON._id.toString(),
+          deadline: issue2JSON.deadline.toISOString(),
+          createdAt: issue2JSON.createdAt.toISOString(),
+        },
+      ],
+    });
+  });
+});

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -247,3 +247,71 @@ describe('GET /api/v1/issues', () => {
     });
   });
 });
+
+describe('DELETE /api/v1/issues/:id', () => {
+  test('if an invalid ID is provided, should return 400', async () => {
+    // Arrange.
+    const issue = await Issue.create({
+      status: '1 = backlog',
+      deadline: new Date('2024-08-22T20:40:41.277Z'),
+      description: 'generate code coverage reports in HTML format',
+    });
+
+    const issueId = issue._id.toString();
+    const invalidId = issueId.slice(0, issueId.length - 1);
+
+    // Act.
+    response = await request(app).delete(`/api/v1/issues/${invalidId}`);
+
+    // Assert.
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({
+      message: 'Invalid ID provided',
+    });
+  });
+
+  test('if a non-existent ID is provided, should return 404', async () => {
+    // Arrange.
+    const issue = await Issue.create({
+      status: '1 = backlog',
+      deadline: new Date('2024-08-22T20:40:41.277Z'),
+      description: 'generate code coverage reports in HTML format',
+    });
+
+    const issueId = issue._id.toString();
+    const notLastDigitOfId =
+      issueId.charAt(issueId.length - 1) == '0' ? '1' : '0';
+    const nonexistentId =
+      issueId.slice(0, issueId.length - 1) + notLastDigitOfId;
+
+    // Act.
+    const response = await request(app).delete(
+      `/api/v1/issues/${nonexistentId}`
+    );
+
+    // Assert.
+    expect(response.status).toEqual(404);
+    expect(response.body).toEqual({
+      message: 'Resource not found',
+    });
+  });
+
+  test('if a valid ID is provided, should return 204', async () => {
+    // Arrange.
+    const issue = await Issue.create({
+      status: '1 = backlog',
+      deadline: new Date('2024-08-22T20:40:41.277Z'),
+      description: 'generate code coverage reports in HTML format',
+    });
+
+    const issueId = issue._id.toString();
+
+    // Act.
+    const response = await request(app).delete(`/api/v1/issues/${issueId}`);
+
+    // Assert.
+    expect(response.status).toEqual(204);
+    expect(response.headers['content-length']).toEqual('0');
+    expect(response.body).toEqual({});
+  });
+});

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -3,7 +3,7 @@ const request = require('supertest');
 const app = require('../src/app');
 
 describe('GET /api/v1/issues/:id', () => {
-  test('if ID does not exist, should return 404', async () => {
+  xtest('if ID does not exist, should return 404', async () => {
     // Act.
     const response = await request(app).get('/api/v1/issues/17');
 
@@ -14,7 +14,7 @@ describe('GET /api/v1/issues/:id', () => {
     });
   });
 
-  test('if ID exists, should return 200 and corresponding issue', async () => {
+  xtest('if ID exists, should return 200 and corresponding issue', async () => {
     // Act.
     const response = await request(app).get('/api/v1/issues/1');
 
@@ -34,7 +34,7 @@ describe('GET /api/v1/issues/:id', () => {
 });
 
 describe('POST /api/v1/issues', () => {
-  test('if "status" is missing, should return 400', async () => {
+  xtest('if "status" is missing, should return 400', async () => {
     // Act.
     const response = await request(app).post('/api/v1/issues').send({
       description: 'containerize the backend',
@@ -48,7 +48,7 @@ describe('POST /api/v1/issues', () => {
     });
   });
 
-  test('if "description" is missing, should return 400', async () => {
+  xtest('if "description" is missing, should return 400', async () => {
     // Act.
     const response = await request(app).post('/api/v1/issues').send({
       status: '1 = backlog',
@@ -62,7 +62,7 @@ describe('POST /api/v1/issues', () => {
     });
   });
 
-  xtest('if "status" and "description", should return 201', async () => {
+  test('if "status" and "description", should return 201', async () => {
     // Act.
     const response = await request(app).post('/api/v1/issues').send({
       status: '1 = backlog',

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -117,3 +117,78 @@ describe('POST /api/v1/issues', () => {
     });
   });
 });
+
+describe('PUT /api/v1/issues/:id', () => {
+  test('if a invalid ID is provided, should return 400', async () => {
+    // Arrange.
+    const issue = await Issue.create({
+      status: '1 = backlog',
+      deadline: new Date('2024-08-20T20:34:07.386Z'),
+      description: 'code cvrg reports in HTML',
+    });
+
+    const issueId = issue._id.toString();
+    const invalidId = issueId.slice(0, issueId.length - 1);
+
+    // Act.
+    const response = await request(app).put(`/api/v1/issues/${invalidId}`);
+
+    // Assert.
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({
+      message: 'Invalid ID provided',
+    });
+  });
+
+  test('if a non-existent ID is provided, should return 404', async () => {
+    // Arrange.
+    const issue = await Issue.create({
+      status: '1 = backlog',
+      deadline: new Date('2024-08-20T20:18:09.763Z'),
+      description: 'code cvrg reports in HTML',
+    });
+
+    const issueId = issue._id.toString();
+    const notLastDigitOfId =
+      issueId.charAt(issueId.length - 1) == '0' ? '1' : '0';
+    const nonexistentId =
+      issueId.slice(0, issueId.length - 1) + notLastDigitOfId;
+
+    // Act.
+    const response = await request(app).put(`/api/v1/issues/${nonexistentId}`);
+
+    // Assert.
+    expect(response.status).toEqual(404);
+    expect(response.body).toEqual({
+      message: 'Resource not found',
+    });
+  });
+
+  test('if a valid ID is provided, should return 200', async () => {
+    // Arrange.
+    const issue = await Issue.create({
+      status: '1 = backlog',
+      deadline: new Date('2024-08-20T20:38:18.162Z'),
+      description: 'code cvrg reports in HTML',
+    });
+
+    const issueId = issue._id.toString();
+
+    // Act.
+    const response = await request(app).put(`/api/v1/issues/${issueId}`).send({
+      status: '2 = selected',
+      description: 'generate code coverage reports in HTML format',
+    });
+
+    // Assert.
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      __v: expect.anything(),
+      _id: issueId,
+      createdAt: expect.anything(),
+      status: '2 = selected',
+      deadline: '2024-08-20T20:38:18.162Z',
+      description: 'generate code coverage reports in HTML format',
+    });
+  });
+});

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -1,6 +1,25 @@
+const mms = require('mongodb-memory-server');
+const mongoose = require('mongoose');
 const request = require('supertest');
 
 const app = require('../src/app');
+
+let mongoMemoryServer;
+
+beforeAll(async () => {
+  mongoMemoryServer = await mms.MongoMemoryServer.create();
+  const uri = mongoMemoryServer.getUri();
+  await mongoose.connect(uri);
+});
+
+beforeEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoMemoryServer.stop();
+});
 
 describe('GET /api/v1/issues/:id', () => {
   xtest('if ID does not exist, should return 404', async () => {
@@ -77,11 +96,12 @@ describe('POST /api/v1/issues', () => {
     // Assert.
     expect(response.status).toEqual(201);
     expect(response.body).toEqual({
-      id: 4,
-      createdAt: new Date(),
+      __v: expect.anything(),
+      _id: expect.anything(),
+      createdAt: '2024-08-17T09:00:00.000Z',
       status: '1 = backlog',
-      deadline: null,
-      finishedAt: null,
+      deadline: '2024-08-19T09:00:00.000Z',
+      epic: 'backend',
       description: 'containerize the backend',
     });
   });

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -64,16 +64,21 @@ describe('POST /api/v1/issues', () => {
 
   test('if "status" and "description", should return 201', async () => {
     // Act.
-    const response = await request(app).post('/api/v1/issues').send({
-      status: '1 = backlog',
-      description: 'containerize the backend',
-    });
+    const response = await request(app)
+      .post('/api/v1/issues')
+      .send({
+        createdAt: new Date('2024-08-17T09:00:00.000Z'),
+        status: '1 = backlog',
+        deadline: new Date('2024-08-19T09:00:00.000Z'),
+        epic: 'backend',
+        description: 'containerize the backend',
+      });
 
     // Assert.
     expect(response.status).toEqual(201);
     expect(response.body).toEqual({
       id: 4,
-      createdAt: null,
+      createdAt: new Date(),
       status: '1 = backlog',
       deadline: null,
       finishedAt: null,

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const request = require('supertest');
 
 const app = require('../src/app');
+const Issue = require('../src/models');
 
 console.log('process.env.HOME =', process.env.HOME);
 console.log('process.env.LD_LIBRARY_PATH =', process.env.LD_LIBRARY_PATH);
@@ -25,32 +26,41 @@ afterAll(async () => {
 });
 
 describe('GET /api/v1/issues/:id', () => {
-  xtest('if ID does not exist, should return 404', async () => {
+  test('if ID does not exist, should return 404', async () => {
     // Act.
     const response = await request(app).get('/api/v1/issues/17');
 
     // Assert.
-    expect(response.status).toEqual(404);
+    expect(response.status).toEqual(400);
     expect(response.body).toEqual({
-      message: 'Resource not found',
+      message: 'Invalid ID provided',
     });
   });
 
-  xtest('if ID exists, should return 200 and corresponding issue', async () => {
+  test('if ID exists, should return 200 and corresponding issue', async () => {
+    // Arrange.
+    const deadline = new Date('2024-08-19T06:17:17.170Z');
+    const issue = await Issue.create({
+      status: '1 = backlog',
+      deadline,
+      epic: 'ease of development',
+      description: 'introduce code coverage reports in HTML format',
+    });
+
     // Act.
-    const response = await request(app).get('/api/v1/issues/1');
+    const response = await request(app).get(`/api/v1/issues/${issue._id}`);
 
     // Assert.
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
-      id: 1,
-      createdAt: null,
-      status: '3 = in progress',
-      deadline: null,
-      finishedAt: null,
-      epic: 'backend',
-      description:
-        'build a backend application using Express (without a persistence layer)',
+      __v: expect.anything(),
+      _id: issue.id,
+      createdAt: issue.createdAt.toISOString(),
+      status: '1 = backlog',
+      deadline: deadline.toISOString(),
+      // finishedAt: null,
+      epic: 'ease of development',
+      description: 'introduce code coverage reports in HTML format',
     });
   });
 });

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -4,6 +4,9 @@ const request = require('supertest');
 
 const app = require('../src/app');
 
+console.log('process.env.HOME =', process.env.HOME);
+console.log('process.env.LD_LIBRARY_PATH =', process.env.LD_LIBRARY_PATH);
+
 let mongoMemoryServer;
 
 beforeAll(async () => {

--- a/clean-docker-artifacts.sh
+++ b/clean-docker-artifacts.sh
@@ -1,0 +1,3 @@
+docker container rm -f container-m-j-3-mongo
+
+docker volume rm -f volume-m-j-3-mongo

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "jest": "^29.7.0",
+        "mongodb-memory-server": "^10.0.0",
         "nodemon": "^3.1.4",
         "supertest": "^7.0.0"
       }
@@ -1227,6 +1228,44 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1306,12 +1345,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1446,6 +1502,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1575,6 +1639,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -1816,6 +1890,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -2258,6 +2339,13 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2313,6 +2401,50 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2325,6 +2457,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {
@@ -2622,6 +2775,45 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3832,6 +4024,83 @@
         "whatwg-url": "^13.0.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.0.0.tgz",
+      "integrity": "sha512-7Geo/s4lst/QHw+N8/stdnyb08xn68O0zbSee62jgoPfWOXfSPhX9a8OvyOY/o23oYk9ra2EpA2Oejenb3JKfw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "10.0.0",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.0.0.tgz",
+      "integrity": "sha512-AdYi4nVqe3Pk95fRJ+DegbDdEfAG9wujNsVvJWbwh8+ZJd+d3JJK1PHxRyJ9rMvoczvlli5M30eMig7zBuF5pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.5",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^7.0.5",
+        "mongodb": "^6.7.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.6.3",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.6.3",
+        "yauzl": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mongoose": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.5.3.tgz",
@@ -3953,6 +4222,44 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4230,6 +4537,13 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "license": "MIT"
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -4375,6 +4689,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -4731,6 +5052,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -4905,6 +5241,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -4918,6 +5266,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tmpl": {
@@ -4980,6 +5338,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -5233,6 +5598,20 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.3.tgz",
+      "integrity": "sha512-JCCdmlJJWv7L0q/KylOekyRaUrdEoUxWkWVcgorosTROCFWiS9p2NNPE9Yb91ak7b1N5SxAZEliWpspbZccivw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "mongoose": "^8.5.3",
         "morgan": "^1.10.0"
@@ -2029,6 +2030,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.19.2",
+        "mongoose": "^8.5.3",
         "morgan": "^1.10.0"
       },
       "devDependencies": {
@@ -1045,6 +1046,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.8.tgz",
+      "integrity": "sha512-qKwC/M/nNNaKUBMQ0nuzm47b7ZYWQHN3pcXq4IIcoSBc2hOIrflAxJduIvvqmhoz3gR2TacTAs8vlsCVPkiEdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1170,6 +1180,21 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -1540,6 +1565,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
+      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer-from": {
@@ -3537,6 +3571,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -3621,6 +3664,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -3714,6 +3763,90 @@
         "node": "*"
       }
     },
+    "node_modules/mongodb": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.7.0.tgz",
+      "integrity": "sha512-TMKyHdtMcO0fYBNORiYdmM25ijsHs+Njs963r4Tro4OQZzqYigAzYQouwWRg4OIaiLRUEGUh/1UAcH5lxdSLIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.5.3.tgz",
+      "integrity": "sha512-OubSDbsAclDFGHjV82MsKyIGQWFc42Ot1l+0dhRS6U9xODM7rm/ES/WpOQd8Ds9j0Mx8QzxZtrSCnBh6o9wUqw==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.7.0",
+        "kareem": "2.6.3",
+        "mongodb": "6.7.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -3741,6 +3874,50 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/mquery/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mquery/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -4145,6 +4322,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -4430,6 +4616,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4486,6 +4678,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {
@@ -4755,6 +4956,18 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4886,6 +5099,28 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Kaloyan Marinov",
   "license": "MIT",
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "mongoose": "^8.5.3",
     "morgan": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
+    "mongodb-memory-server": "^10.0.0",
     "nodemon": "^3.1.4",
     "supertest": "^7.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.19.2",
+    "mongoose": "^8.5.3",
     "morgan": "^1.10.0"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -62,26 +62,42 @@ app.post('/api/v1/issues', async (req, res, next) => {
   res.status(201).json(newIssue);
 });
 
-app.get('/api/v1/issues', (req, res) => {
-  res.status(200).json({
-    resources: issues,
-  });
+app.get('/api/v1/issues/:id', async (req, res) => {
+  const issueId = req.params.id;
+  try {
+    const issue = await Issue.findById(issueId);
+
+    if (!issue) {
+      return res.status(404).json({
+        message: 'Resource not found',
+      });
+    }
+
+    res.status(200).json(issue);
+  } catch (err) {
+    res.status(400).json({
+      message: 'Invalid ID provided',
+    });
+  }
 });
 
-app.get('/api/v1/issues/:id', (req, res) => {
-  const issueId = parseInt(req.params.id);
-  // console.log(issueId);
-  const issue = issues.find((i) => i.id === issueId);
+app.get('/api/v1/issues/:id', async (req, res) => {
+  const issueId = req.params.id;
+  try {
+    const issue = await Issue.findById(issueId);
 
-  if (!issue) {
-    res.status(404).json({
-      message: 'Resource not found',
+    if (!issue) {
+      return res.status(404).json({
+        message: 'Resource not found',
+      });
+    }
+
+    res.status(200).json(issue);
+  } catch (err) {
+    res.status(400).json({
+      message: 'Invalid ID provided',
     });
-
-    return;
   }
-
-  res.status(200).json(issue);
 });
 
 app.put('/api/v1/issues/:id', (req, res) => {

--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV === 'development') {
   app.use(morgan('dev'));
 }
 
-app.post('/api/v1/issues', async (req, res, next) => {
+app.post('/api/v1/issues', async (req, res) => {
   let newIssue;
 
   try {

--- a/src/app.js
+++ b/src/app.js
@@ -2,37 +2,6 @@ const express = require('express');
 const morgan = require('morgan');
 const Issue = require('./models');
 
-const issues = [
-  {
-    id: 1,
-    createdAt: null,
-    status: '3 = in progress',
-    deadline: null,
-    finishedAt: null,
-    epic: 'backend',
-    description:
-      'build a backend application using Express (without a persistence layer)',
-  },
-  {
-    id: 2,
-    createdAt: null,
-    status: '1 = backlog',
-    deadline: null,
-    finishedAt: null,
-    epic: 'ease of development',
-    description: 'make it possible to use VS Code to serve the backend',
-  },
-  {
-    id: 3,
-    createdAt: null,
-    status: '1 = backlog',
-    deadline: null,
-    finishedAt: null,
-    epic: 'backend',
-    description: 'implement a persistence layer using MongoDB',
-  },
-];
-
 const app = express();
 
 // This middleware function enables the backend application
@@ -124,23 +93,27 @@ app.put('/api/v1/issues/:id', async (req, res) => {
   res.status(200).json(issue);
 });
 
-app.delete('/api/v1/issues/:id', (req, res) => {
-  // Check if an existing issue is targeted.
-  const issueId = parseInt(req.params.id);
+app.delete('/api/v1/issues/:id', async (req, res) => {
+  let issue;
+  const issueId = req.params.id;
 
-  const issueIndex = issues.findIndex((i) => i.id === issueId);
-
-  if (issueIndex === -1) {
-    res.status(404).json({
-      message: 'Resource not found',
+  try {
+    issue = await Issue.findById(issueId);
+  } catch (err) {
+    return res.status(400).json({
+      message: 'Invalid ID provided',
     });
-
-    return;
   }
 
-  issues.splice(issueIndex, 1);
+  if (!issue) {
+    return res.status(404).json({
+      message: 'Resource not found',
+    });
+  }
 
-  res.status(204).json({});
+  await issue.deleteOne();
+  res.set('Content-Length', '0');
+  res.status(204).end();
 });
 
 module.exports = app;

--- a/src/app.js
+++ b/src/app.js
@@ -62,21 +62,18 @@ app.post('/api/v1/issues', async (req, res, next) => {
   res.status(201).json(newIssue);
 });
 
-app.get('/api/v1/issues/:id', async (req, res) => {
-  const issueId = req.params.id;
+app.get('/api/v1/issues', async (req, res) => {
   try {
-    const issue = await Issue.findById(issueId);
+    const issues = await Issue.find();
 
-    if (!issue) {
-      return res.status(404).json({
-        message: 'Resource not found',
-      });
-    }
-
-    res.status(200).json(issue);
+    res.status(200).json({
+      resources: issues,
+    });
   } catch (err) {
-    res.status(400).json({
-      message: 'Invalid ID provided',
+    console.error(err);
+
+    res.status(500).json({
+      message: 'Failed to process your HTTP request',
     });
   }
 });

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const morgan = require('morgan');
+const Issue = require('./models');
 
 const issues = [
   {
@@ -43,31 +44,20 @@ if (process.env.NODE_ENV === 'development') {
   app.use(morgan('dev'));
 }
 
-app.post('/api/v1/issues', (req, res, next) => {
-  const { status, epic, description } = req.body;
+app.post('/api/v1/issues', async (req, res, next) => {
+  let newIssue;
 
-  if (!status || !description) {
+  try {
+    newIssue = await Issue.create(req.body);
+  } catch (err) {
+    console.error(err);
+
     res.status(400).json({
-      message:
-        "Each of 'status', 'description' must be specified in" +
-        " the HTTP request's body",
+      message: 'Unable to create a new issue.',
     });
 
     return;
   }
-
-  const existingIds = issues.map((issuer) => issuer.id);
-  const newId = Math.max(...existingIds) + 1;
-  const newIssue = {
-    id: newId,
-    createdAt: null,
-    status,
-    deadline: null,
-    finishedAt: null,
-    epic,
-    description,
-  };
-  issues.push(newIssue);
 
   res.status(201).json(newIssue);
 });

--- a/src/app.js
+++ b/src/app.js
@@ -15,7 +15,7 @@ const issues = [
   {
     id: 2,
     createdAt: null,
-    status: '1 = in backlog',
+    status: '1 = backlog',
     deadline: null,
     finishedAt: null,
     epic: 'ease of development',
@@ -24,7 +24,7 @@ const issues = [
   {
     id: 3,
     createdAt: null,
-    status: '1 = in backlog',
+    status: '1 = backlog',
     deadline: null,
     finishedAt: null,
     epic: 'backend',

--- a/src/app.js
+++ b/src/app.js
@@ -48,22 +48,23 @@ app.get('/api/v1/issues', async (req, res) => {
 });
 
 app.get('/api/v1/issues/:id', async (req, res) => {
+  let issue;
   const issueId = req.params.id;
   try {
-    const issue = await Issue.findById(issueId);
-
-    if (!issue) {
-      return res.status(404).json({
-        message: 'Resource not found',
-      });
-    }
-
-    res.status(200).json(issue);
+    issue = await Issue.findById(issueId);
   } catch (err) {
-    res.status(400).json({
+    return res.status(400).json({
       message: 'Invalid ID provided',
     });
   }
+
+  if (!issue) {
+    return res.status(404).json({
+      message: 'Resource not found',
+    });
+  }
+
+  res.status(200).json(issue);
 });
 
 app.put('/api/v1/issues/:id', async (req, res) => {
@@ -76,9 +77,6 @@ app.put('/api/v1/issues/:id', async (req, res) => {
       message: 'Invalid ID provided',
     });
   }
-  // TODO: (2024/08/20, 22:03)
-  //       the preceding `try`/`except` differs from the one in `app.get` -
-  //       look into rendering them consistent with each other
 
   if (!issue) {
     return res.status(404).json({
@@ -96,7 +94,6 @@ app.put('/api/v1/issues/:id', async (req, res) => {
 app.delete('/api/v1/issues/:id', async (req, res) => {
   let issue;
   const issueId = req.params.id;
-
   try {
     issue = await Issue.findById(issueId);
   } catch (err) {

--- a/src/database.js
+++ b/src/database.js
@@ -13,7 +13,6 @@ const connectToDatabase = async () => {
       dbName: process.env.MONGO_DATABASE,
     }
   );
-  // const connection = await mongoose.connect(process.env.MONGO_URI);
 
   console.log(
     `Established connection to MongoDB host at ${connection.connection.host}:${connection.connection.port} ${connection.connection.db.databaseName}`

--- a/src/database.js
+++ b/src/database.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+const connectToDatabase = async () => {
+  console.log('Establishing connection to MongoDB host...');
+
+  const connection = await mongoose.connect(
+    'mongodb://' +
+      // 'srv+mongoadmin:secret@localhost:27017' +
+      // 'mongoadmin:secret@localhost:27017' +
+      'mongoadmin:secret@localhost' +
+      '/admin?retryWrites=true&w=majority',
+    {
+      dbName: 'db-mini-jira-3',
+    }
+  );
+  // const connection = await mongoose.connect(process.env.MONGO_URI);
+
+  console.log(
+    `Established connection to MongoDB host at ${connection.connection.host}:${connection.connection.port} ${connection.connection.db.databaseName}`
+  );
+};
+
+module.exports = connectToDatabase;

--- a/src/database.js
+++ b/src/database.js
@@ -5,12 +5,12 @@ const connectToDatabase = async () => {
 
   const connection = await mongoose.connect(
     'mongodb://' +
-      // 'srv+mongoadmin:secret@localhost:27017' +
-      // 'mongoadmin:secret@localhost:27017' +
-      'mongoadmin:secret@localhost' +
-      '/admin?retryWrites=true&w=majority',
+      `${process.env.MONGO_USERNAME}:${process.env.MONGO_PASSWORD}` +
+      `@${process.env.MONGO_HOST}` +
+      `/${process.env.MONGO_AUTHENTICATION_DATABASE}` +
+      '?retryWrites=true&w=majority',
     {
-      dbName: 'db-mini-jira-3',
+      dbName: process.env.MONGO_DATABASE,
     }
   );
   // const connection = await mongoose.connect(process.env.MONGO_URI);

--- a/src/models.js
+++ b/src/models.js
@@ -1,0 +1,39 @@
+const mongoose = require('mongoose');
+
+const IssueSchema = new mongoose.Schema({
+  createdAt: {
+    type: Date,
+    required: [true, 'Please specify a value for "createdAt".'],
+    default: Date.now,
+  },
+  status: {
+    type: String,
+    enum: [
+      '1 = backlog',
+      '2 = selected',
+      '3 = in progress',
+      '4 = done',
+      '5 = will not do',
+    ],
+    required: true,
+  },
+  deadline: {
+    type: Date,
+    required: [true, 'Please specify a value for "deadline".'],
+  },
+  finishedAt: {
+    type: Date,
+  },
+  // TODO: (2024/08/17, 11:27) convert the following to a nullable reference to `this._id`
+  epic: {
+    type: String,
+  },
+  description: {
+    type: String,
+    required: [true, 'Please specify a value for "description".'],
+  },
+});
+
+const Issue = new mongoose.model('Issue', IssueSchema);
+
+module.exports = Issue;

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,11 @@
+const dotenv = require('dotenv');
 const connectToDatabase = require('./database');
 const app = require('./app');
+
+// Load all environment variables, which are set in a file at the specified path.
+dotenv.config({
+  path: '.env',
+});
 
 const connectToDatabasePromise = connectToDatabase();
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,10 +1,16 @@
 const connectToDatabase = require('./database');
 const app = require('./app');
 
-connectToDatabase();
+const connectToDatabasePromise = connectToDatabase();
 
-const PORT = 5000;
+connectToDatabasePromise
+  .then(() => {
+    const PORT = 5000;
 
-app.listen(PORT, () => {
-  console.log(`Server is listening on port ${PORT}`);
-});
+    app.listen(PORT, () => {
+      console.log(`Server is listening on port ${PORT}`);
+    });
+  })
+  .catch((err) => {
+    console.error(err);
+  });

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,7 @@
+const connectToDatabase = require('./database');
 const app = require('./app');
+
+connectToDatabase();
 
 const PORT = 5000;
 


### PR DESCRIPTION
this pull request:

- enhanced the web application
  by endowing it with a persistence layer - in the form of a MongoDB server

- arranges for each one of the automated test
  to use an in-memory MongoDB server which exists only for the duration of that specific test;
  fortunately, achieving that does not require any complicated/mystifying code -
  all it takes is [this small number of statements](
    https://github.com/kaloyan-marinov/mini-jira-3/blob/fac4f9d55abd9e813ccf8580d8b7241245e4ab2b/__test__/app.test.js#L11-L26
  ) 