### PR TITLE
Enhance the `GET /api/v1/issues` handler to perform pagination (plus _optional_ filtering, specific-field-selection, and/or sorting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,9 @@ in it, issue the following requests to the HTTP server:
       'localhost:5000/api/v1/issues?deadline\[lte\]=2024-08-23' \
       | json_pp
    
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
    {
       "resources" : [
          {
@@ -361,6 +364,35 @@ in it, issue the following requests to the HTTP server:
             "description" : "containerize the backend",
             "epic" : "backend",
             "status" : "3 = in progress"
+         }
+      ]
+   }
+   ```
+
+   ```bash
+   curl -v \
+      'localhost:5000/api/v1/issues?select=description,status' \
+      | json_pp
+   
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
+   {
+      "resources" : [
+         {
+            "_id" : "66cf7dbbc96812bec9925392",
+            "description" : "containerize the backend",
+            "status" : "3 = in progress"
+         },
+         {
+            "_id" : "66cf7eb7c96812bec9925394",
+            "description" : "convert the `epic` field to a `parentId` field",
+            "status" : "1 = backlog"
+         },
+         {
+            "_id" : "66cf7edfc96812bec9925396",
+            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+            "status" : "2 = selected"
          }
       ]
    }

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ curl -v \
 # ...
 ```
 
+<u>TODO: (2024/08/31, 19:20) swap the order of the last 2 HTTP requests ("and their statuses")</u>
+
 ```bash
 curl -v \
    -X POST \
@@ -341,7 +343,7 @@ curl -v \
 }
 ```
 
-<u>TODO: (2024/08/31, 19:04) the `total` returned in the response to the next request is incorrect - write a test, which catches this bug, and fix the request-handling function</u>
+<u>TODO: (2024/08/31, 19:04) the `total` returned in the response to the next request is incorrect - that is a bug; the commit introducing this line also introduces a test, which catches the bug</u>
 
 ```bash
 curl -v \

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ curl -v \
 
 # ...
 < HTTP/1.1 201 Created
+< Location: /api/v1/issues/66d4bc0775ddfdd6c15a594f
 # ...
 {
    "__v" : 0,

--- a/README.md
+++ b/README.md
@@ -94,7 +94,13 @@ run automated tests
   issue the following command:
 
    ```bash
-   npm run test
+   npm run test -- \
+      --coverage \
+      --collectCoverageFrom="./src/**"
+
+   # The preceding command generates a file located at
+   # `coverage/lcov-report/index.html`
+   # which can be opened in a web browser.
    ```
 
 - to run a specific automated test <u>in debug mode</u>,
@@ -116,7 +122,13 @@ run automated tests
 
    ```bash
    npm run test -- \
+      --coverage \
+      --collectCoverageFrom="./src/**" \
       --watchAll
+
+   # The preceding command generates a file located at
+   # `coverage/lcov-report/index.html`
+   # which can be opened in a web browser.
    ```
 
 [step 4]

--- a/README.md
+++ b/README.md
@@ -478,6 +478,29 @@ in it, issue the following requests to the HTTP server:
    }
    ```
 
+   ```bash
+   curl -v \
+      'localhost:5000/api/v1/issues?perPage=2&page=2' \
+      | json_pp
+
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
+   {
+      "resources" : [
+         {
+            "__v" : 0,
+            "_id" : "66cf7edfc96812bec9925396",
+            "createdAt" : "2024-08-28T19:47:43.611Z",
+            "deadline" : "2024-08-28T19:45:24.081Z",
+            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+            "epic" : "frontend",
+            "status" : "2 = selected"
+         }
+      ]
+   }
+   ```
+
 
 
 - retrieve one

--- a/README.md
+++ b/README.md
@@ -235,9 +235,45 @@ curl -v \
 ```
 
 ```bash
-export ISSUE_1_ID=<the-_id-present-in-the-preceding-HTTP-response>
+curl -v \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d "{
+         \"status\": \"1 = backlog\",
+         \"deadline\": \"2024-08-28T19:45:08.246Z\",
+         \"epic\": \"backend\",
+         \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
+    }" \
+  localhost:5000/api/v1/issues \
+  | json_pp
 
-export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_1_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
+# ...
+< HTTP/1.1 201 Created
+# ...
+```
+
+```bash
+curl -v \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d "{
+         \"status\": \"1 = backlog\",
+         \"deadline\": \"2024-08-28T19:45:24.081Z\",
+         \"epic\": \"frontend\",
+         \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
+    }" \
+  localhost:5000/api/v1/issues \
+  | json_pp
+
+# ...
+< HTTP/1.1 201 Created
+# ...
+```
+
+```bash
+export ISSUE_3_ID=<the-_id-present-in-the-preceding-HTTP-response>
+
+export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_3_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
 ```
 
 
@@ -254,12 +290,53 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66c4f458e3788fc8e79d0c89",
-         "createdAt" : "2024-08-20T19:54:00.804Z",
+         "_id" : "66cf7dbbc96812bec9925392",
+         "createdAt" : "2024-08-28T19:42:51.501Z",
          "deadline" : "2024-08-19T09:00:00.000Z",
          "description" : "containerize the backend",
          "epic" : "backend",
-         "status" : "4 = done"
+         "status" : "1 = backlog"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66cf7eb7c96812bec9925394",
+         "createdAt" : "2024-08-28T19:47:03.691Z",
+         "deadline" : "2024-08-28T19:45:08.246Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "epic" : "backend",
+         "status" : "1 = backlog"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66cf7edfc96812bec9925396",
+         "createdAt" : "2024-08-28T19:47:43.611Z",
+         "deadline" : "2024-08-28T19:45:24.081Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
+         "status" : "1 = backlog"
+      }
+   ]
+}
+```
+
+```bash
+curl -v \
+  localhost:5000/api/v1/issues?epic=frontend \
+  | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66cf7edfc96812bec9925396",
+         "createdAt" : "2024-08-28T19:47:43.611Z",
+         "deadline" : "2024-08-28T19:45:24.081Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
+         "status" : "1 = backlog"
       }
    ]
 }
@@ -295,7 +372,7 @@ curl -v \
 
 ```bash
 curl -v \
-  localhost:5000/api/v1/issues/${ISSUE_1_ID} \
+  localhost:5000/api/v1/issues/${ISSUE_3_ID} \
   | json_pp
 
 # ...
@@ -349,7 +426,7 @@ curl -v \
   -d "{
          \"status\": \"4 = done\"
     }" \
-  localhost:5000/api/v1/issues/${ISSUE_1_ID} \
+  localhost:5000/api/v1/issues/${ISSUE_3_ID} \
   | json_pp
 
 # ...
@@ -399,7 +476,7 @@ curl -v \
 ```bash
 curl -v \
   -X DELETE \
-  localhost:5000/api/v1/issues/${ISSUE_1_ID}
+  localhost:5000/api/v1/issues/${ISSUE_3_ID}
 
 # ...
 < HTTP/1.1 204 No Content

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d3949e139d0bb7b82243ae",
-   "createdAt" : "2024-08-31T22:09:34.087Z",
+   "_id" : "66d4bc0775ddfdd6c15a594f",
+   "createdAt" : "2024-09-01T19:09:59.779Z",
    "deadline" : "2024-08-31T21:08:36.367Z",
    "description" : "convert the `epic` field to a `parentId` field",
    "epic" : "backend",
@@ -307,6 +307,8 @@ curl -v \
 {
    "meta" : {
       "curr" : "/api/v1/issues?perPage=100&page=1",
+      "first" : "/api/v1/issues?perPage=100&page=1",
+      "last" : "/api/v1/issues?perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 3
@@ -314,8 +316,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d3949e139d0bb7b82243ae",
-         "createdAt" : "2024-08-31T22:09:34.087Z",
+         "_id" : "66d4bc0775ddfdd6c15a594f",
+         "createdAt" : "2024-09-01T19:09:59.779Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
          "epic" : "backend",
@@ -323,8 +325,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d394b1139d0bb7b82243b0",
-         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "_id" : "66d4bc1675ddfdd6c15a5951",
+         "createdAt" : "2024-09-01T19:10:14.645Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "epic" : "frontend",
@@ -332,8 +334,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d394d3139d0bb7b82243b2",
-         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "_id" : "66d4bc2075ddfdd6c15a5953",
+         "createdAt" : "2024-09-01T19:10:24.140Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
          "epic" : "backend",
@@ -354,6 +356,8 @@ curl -v \
 {
    "meta" : {
       "curr" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
+      "first" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
+      "last" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 1
@@ -361,8 +365,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d394b1139d0bb7b82243b0",
-         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "_id" : "66d4bc1675ddfdd6c15a5951",
+         "createdAt" : "2024-09-01T19:10:14.645Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "epic" : "frontend",
@@ -385,6 +389,8 @@ curl -v \
 {
    "meta" : {
       "curr" : "/api/v1/issues?status=%5Bobject+Object%5D&perPage=100&page=1",
+      "first" : "/api/v1/issues?status=%5Bobject+Object%5D&perPage=100&page=1",
+      "last" : "/api/v1/issues?status=%5Bobject+Object%5D&perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 2
@@ -392,8 +398,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d394b1139d0bb7b82243b0",
-         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "_id" : "66d4bc1675ddfdd6c15a5951",
+         "createdAt" : "2024-09-01T19:10:14.645Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "epic" : "frontend",
@@ -401,8 +407,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d394d3139d0bb7b82243b2",
-         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "_id" : "66d4bc2075ddfdd6c15a5953",
+         "createdAt" : "2024-09-01T19:10:24.140Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
          "epic" : "backend",
@@ -423,23 +429,25 @@ curl -v \
 {
    "meta" : {
       "curr" : "/api/v1/issues?select=description%2Cstatus&perPage=100&page=1",
+      "first" : "/api/v1/issues?select=description%2Cstatus&perPage=100&page=1",
+      "last" : "/api/v1/issues?select=description%2Cstatus&perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 3
    },
    "resources" : [
       {
-         "_id" : "66d3949e139d0bb7b82243ae",
+         "_id" : "66d4bc0775ddfdd6c15a594f",
          "description" : "convert the `epic` field to a `parentId` field",
          "status" : "3 = in progress"
       },
       {
-         "_id" : "66d394b1139d0bb7b82243b0",
+         "_id" : "66d4bc1675ddfdd6c15a5951",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "status" : "1 = backlog"
       },
       {
-         "_id" : "66d394d3139d0bb7b82243b2",
+         "_id" : "66d4bc2075ddfdd6c15a5953",
          "description" : "containerize the backend",
          "status" : "2 = selected"
       }
@@ -458,6 +466,8 @@ curl -v \
 {
    "meta" : {
       "curr" : "/api/v1/issues?sort=-status&perPage=100&page=1",
+      "first" : "/api/v1/issues?sort=-status&perPage=100&page=1",
+      "last" : "/api/v1/issues?sort=-status&perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 3
@@ -465,8 +475,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d3949e139d0bb7b82243ae",
-         "createdAt" : "2024-08-31T22:09:34.087Z",
+         "_id" : "66d4bc0775ddfdd6c15a594f",
+         "createdAt" : "2024-09-01T19:09:59.779Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
          "epic" : "backend",
@@ -474,8 +484,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d394d3139d0bb7b82243b2",
-         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "_id" : "66d4bc2075ddfdd6c15a5953",
+         "createdAt" : "2024-09-01T19:10:24.140Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
          "epic" : "backend",
@@ -483,8 +493,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d394b1139d0bb7b82243b0",
-         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "_id" : "66d4bc1675ddfdd6c15a5951",
+         "createdAt" : "2024-09-01T19:10:14.645Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "epic" : "frontend",
@@ -505,6 +515,8 @@ curl -v \
 {
    "meta" : {
       "curr" : "/api/v1/issues?sort=status&perPage=100&page=1",
+      "first" : "/api/v1/issues?sort=status&perPage=100&page=1",
+      "last" : "/api/v1/issues?sort=status&perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 3
@@ -512,8 +524,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d394b1139d0bb7b82243b0",
-         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "_id" : "66d4bc1675ddfdd6c15a5951",
+         "createdAt" : "2024-09-01T19:10:14.645Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "epic" : "frontend",
@@ -521,8 +533,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d394d3139d0bb7b82243b2",
-         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "_id" : "66d4bc2075ddfdd6c15a5953",
+         "createdAt" : "2024-09-01T19:10:24.140Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
          "epic" : "backend",
@@ -530,8 +542,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d3949e139d0bb7b82243ae",
-         "createdAt" : "2024-08-31T22:09:34.087Z",
+         "_id" : "66d4bc0775ddfdd6c15a594f",
+         "createdAt" : "2024-09-01T19:09:59.779Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
          "epic" : "backend",
@@ -552,6 +564,8 @@ curl -v \
 {
    "meta" : {
       "curr" : "/api/v1/issues?perPage=2&page=2",
+      "first" : "/api/v1/issues?perPage=2&page=1",
+      "last" : "/api/v1/issues?perPage=2&page=2",
       "next" : null,
       "prev" : "/api/v1/issues?perPage=2&page=1",
       "total" : 3
@@ -559,8 +573,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d394d3139d0bb7b82243b2",
-         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "_id" : "66d4bc2075ddfdd6c15a5953",
+         "createdAt" : "2024-09-01T19:10:24.140Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
          "epic" : "backend",
@@ -610,8 +624,8 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d394d3139d0bb7b82243b2",
-   "createdAt" : "2024-08-31T22:10:27.679Z",
+   "_id" : "66d4bc2075ddfdd6c15a5953",
+   "createdAt" : "2024-09-01T19:10:24.140Z",
    "deadline" : "2024-08-31T23:08:36.367Z",
    "description" : "containerize the backend",
    "epic" : "backend",
@@ -666,8 +680,8 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d394d3139d0bb7b82243b2",
-   "createdAt" : "2024-08-31T22:10:27.679Z",
+   "_id" : "66d4bc2075ddfdd6c15a5953",
+   "createdAt" : "2024-09-01T19:10:24.140Z",
    "deadline" : "2024-08-31T23:08:36.367Z",
    "description" : "containerize the backend",
    "epic" : "backend",

--- a/README.md
+++ b/README.md
@@ -398,6 +398,86 @@ in it, issue the following requests to the HTTP server:
    }
    ```
 
+   ```bash
+   curl -v \
+      'localhost:5000/api/v1/issues?sort=-status' \
+      | json_pp
+
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
+   {
+      "resources" : [
+         {
+            "__v" : 0,
+            "_id" : "66cf7dbbc96812bec9925392",
+            "createdAt" : "2024-08-28T19:42:51.501Z",
+            "deadline" : "2024-08-19T09:00:00.000Z",
+            "description" : "containerize the backend",
+            "epic" : "backend",
+            "status" : "3 = in progress"
+         },
+         {
+            "__v" : 0,
+            "_id" : "66cf7edfc96812bec9925396",
+            "createdAt" : "2024-08-28T19:47:43.611Z",
+            "deadline" : "2024-08-28T19:45:24.081Z",
+            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+            "epic" : "frontend",
+            "status" : "2 = selected"
+         },
+         {
+            "__v" : 0,
+            "_id" : "66cf7eb7c96812bec9925394",
+            "createdAt" : "2024-08-28T19:47:03.691Z",
+            "deadline" : "2024-08-28T19:45:08.246Z",
+            "description" : "convert the `epic` field to a `parentId` field",
+            "epic" : "backend",
+            "status" : "1 = backlog"
+         }
+      ]
+   }
+
+   curl -v \
+      'localhost:5000/api/v1/issues?sort=status' \
+      | json_pp
+   
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
+   {
+      "resources" : [
+         {
+            "__v" : 0,
+            "_id" : "66cf7eb7c96812bec9925394",
+            "createdAt" : "2024-08-28T19:47:03.691Z",
+            "deadline" : "2024-08-28T19:45:08.246Z",
+            "description" : "convert the `epic` field to a `parentId` field",
+            "epic" : "backend",
+            "status" : "1 = backlog"
+         },
+         {
+            "__v" : 0,
+            "_id" : "66cf7edfc96812bec9925396",
+            "createdAt" : "2024-08-28T19:47:43.611Z",
+            "deadline" : "2024-08-28T19:45:24.081Z",
+            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+            "epic" : "frontend",
+            "status" : "2 = selected"
+         },
+         {
+            "__v" : 0,
+            "_id" : "66cf7dbbc96812bec9925392",
+            "createdAt" : "2024-08-28T19:42:51.501Z",
+            "deadline" : "2024-08-19T09:00:00.000Z",
+            "description" : "containerize the backend",
+            "epic" : "backend",
+            "status" : "3 = in progress"
+         }
+      ]
+   }
+   ```
+
 
 
 - retrieve one

--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ in it, issue the following requests to the HTTP server:
    < HTTP/1.1 200 OK
    # ...
    {
+      "meta" : {
+         "curr" : "/api/v1/issues?perPage=100&page=1",
+         "next" : null,
+         "prev" : null,
+         "total" : 3
+      },
       "resources" : [
          {
             "__v" : 0,
@@ -299,7 +305,7 @@ in it, issue the following requests to the HTTP server:
             "deadline" : "2024-08-19T09:00:00.000Z",
             "description" : "containerize the backend",
             "epic" : "backend",
-            "status" : "1 = backlog"
+            "status" : "3 = in progress"
          },
          {
             "__v" : 0,
@@ -317,7 +323,7 @@ in it, issue the following requests to the HTTP server:
             "deadline" : "2024-08-28T19:45:24.081Z",
             "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
             "epic" : "frontend",
-            "status" : "1 = backlog"
+            "status" : "2 = selected"
          }
       ]
    }
@@ -332,6 +338,12 @@ in it, issue the following requests to the HTTP server:
    < HTTP/1.1 200 OK
    # ...
    {
+      "meta" : {
+         "curr" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
+         "next" : null,
+         "prev" : null,
+         "total" : 3
+      },
       "resources" : [
          {
             "__v" : 0,
@@ -340,12 +352,13 @@ in it, issue the following requests to the HTTP server:
             "deadline" : "2024-08-28T19:45:24.081Z",
             "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
             "epic" : "frontend",
-            "status" : "1 = backlog"
+            "status" : "2 = selected"
          }
       ]
    }
    ```
 
+   <u>TODO: (2024/08/29; 11:04)</u> consider whether this application needs to support Mongoose operators via URL query strings
    ```bash
    curl -v \
       'localhost:5000/api/v1/issues?deadline\[lte\]=2024-08-23' \
@@ -378,6 +391,12 @@ in it, issue the following requests to the HTTP server:
    < HTTP/1.1 200 OK
    # ...
    {
+      "meta" : {
+         "curr" : "/api/v1/issues?select=description%2Cstatus&perPage=100&page=1",
+         "next" : null,
+         "prev" : null,
+         "total" : 3
+      },
       "resources" : [
          {
             "_id" : "66cf7dbbc96812bec9925392",
@@ -407,6 +426,12 @@ in it, issue the following requests to the HTTP server:
    < HTTP/1.1 200 OK
    # ...
    {
+      "meta" : {
+         "curr" : "/api/v1/issues?sort=-status&perPage=100&page=1",
+         "next" : null,
+         "prev" : null,
+         "total" : 3
+      },
       "resources" : [
          {
             "__v" : 0,
@@ -446,6 +471,12 @@ in it, issue the following requests to the HTTP server:
    < HTTP/1.1 200 OK
    # ...
    {
+      "meta" : {
+         "curr" : "/api/v1/issues?sort=status&perPage=100&page=1",
+         "next" : null,
+         "prev" : null,
+         "total" : 3
+      },
       "resources" : [
          {
             "__v" : 0,
@@ -487,6 +518,12 @@ in it, issue the following requests to the HTTP server:
    < HTTP/1.1 200 OK
    # ...
    {
+      "meta" : {
+         "curr" : "/api/v1/issues?perPage=2&page=2",
+         "next" : null,
+         "prev" : "/api/v1/issues?perPage=2&page=1",
+         "total" : 3
+      },
       "resources" : [
          {
             "__v" : 0,

--- a/README.md
+++ b/README.md
@@ -193,13 +193,13 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X POST \
-   -H "Content-Type: application/json" \
-   -d "{
-            \"status\": \"1 = backlog\"
-      }" \
-   localhost:5000/api/v1/issues \
-   | json_pp
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d "{
+               \"status\": \"1 = backlog\"
+         }" \
+      localhost:5000/api/v1/issues \
+      | json_pp
 
    # ...
    < HTTP/1.1 400 Bad Request
@@ -211,16 +211,16 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X POST \
-   -H "Content-Type: application/json" \
-   -d "{
-            \"status\": \"1 = backlog\",
-            \"deadline\": \"2024-08-19T09:00:00.000Z\",
-            \"epic\": \"backend\",
-            \"description\": \"containerize the backend\"
-      }" \
-   localhost:5000/api/v1/issues \
-   | json_pp
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d "{
+               \"status\": \"1 = backlog\",
+               \"deadline\": \"2024-08-19T09:00:00.000Z\",
+               \"epic\": \"backend\",
+               \"description\": \"containerize the backend\"
+         }" \
+      localhost:5000/api/v1/issues \
+      | json_pp
 
    # ...
    < HTTP/1.1 201 Created
@@ -238,16 +238,16 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X POST \
-   -H "Content-Type: application/json" \
-   -d "{
-            \"status\": \"1 = backlog\",
-            \"deadline\": \"2024-08-28T19:45:08.246Z\",
-            \"epic\": \"backend\",
-            \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
-      }" \
-   localhost:5000/api/v1/issues \
-   | json_pp
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d "{
+               \"status\": \"1 = backlog\",
+               \"deadline\": \"2024-08-28T19:45:08.246Z\",
+               \"epic\": \"backend\",
+               \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
+         }" \
+      localhost:5000/api/v1/issues \
+      | json_pp
 
    # ...
    < HTTP/1.1 201 Created
@@ -256,16 +256,16 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X POST \
-   -H "Content-Type: application/json" \
-   -d "{
-            \"status\": \"1 = backlog\",
-            \"deadline\": \"2024-08-28T19:45:24.081Z\",
-            \"epic\": \"frontend\",
-            \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
-      }" \
-   localhost:5000/api/v1/issues \
-   | json_pp
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d "{
+               \"status\": \"1 = backlog\",
+               \"deadline\": \"2024-08-28T19:45:24.081Z\",
+               \"epic\": \"frontend\",
+               \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
+         }" \
+      localhost:5000/api/v1/issues \
+      | json_pp
 
    # ...
    < HTTP/1.1 201 Created
@@ -284,8 +284,8 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   localhost:5000/api/v1/issues \
-   | json_pp
+      localhost:5000/api/v1/issues \
+      | json_pp
 
    # ...
    < HTTP/1.1 200 OK
@@ -325,8 +325,8 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   localhost:5000/api/v1/issues?epic=frontend \
-   | json_pp
+      localhost:5000/api/v1/issues?epic=frontend \
+      | json_pp
 
    # ...
    < HTTP/1.1 200 OK
@@ -346,14 +346,34 @@ in it, issue the following requests to the HTTP server:
    }
    ```
 
+   ```bash
+   curl -v \
+      'localhost:5000/api/v1/issues?deadline\[lte\]=2024-08-23' \
+      | json_pp
+   
+   {
+      "resources" : [
+         {
+            "__v" : 0,
+            "_id" : "66cf7dbbc96812bec9925392",
+            "createdAt" : "2024-08-28T19:42:51.501Z",
+            "deadline" : "2024-08-19T09:00:00.000Z",
+            "description" : "containerize the backend",
+            "epic" : "backend",
+            "status" : "3 = in progress"
+         }
+      ]
+   }
+   ```
+
 
 
 - retrieve one
 
    ```bash
    curl -v \
-   localhost:5000/api/v1/issues/17 \
-   | json_pp
+      localhost:5000/api/v1/issues/17 \
+      | json_pp
 
    # ...
    < HTTP/1.1 400 Bad Request
@@ -365,8 +385,8 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-   | json_pp
+      localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+      | json_pp
 
    # ...
    < HTTP/1.1 404 Not Found
@@ -378,8 +398,8 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   localhost:5000/api/v1/issues/${ISSUE_3_ID} \
-   | json_pp
+      localhost:5000/api/v1/issues/${ISSUE_3_ID} \
+      | json_pp
 
    # ...
    < HTTP/1.1 200 OK
@@ -401,9 +421,9 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X PUT \
-   localhost:5000/api/v1/issues/17 \
-   | json_pp
+      -X PUT \
+      localhost:5000/api/v1/issues/17 \
+      | json_pp
 
    # ...
    < HTTP/1.1 400 Bad Request
@@ -415,9 +435,9 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X PUT \
-   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-   | json_pp
+      -X PUT \
+      localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+      | json_pp
 
    # ...
    < HTTP/1.1 404 Not Found
@@ -429,13 +449,13 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X PUT \
-   -H "Content-Type: application/json" \
-   -d "{
-            \"status\": \"4 = done\"
-      }" \
-   localhost:5000/api/v1/issues/${ISSUE_3_ID} \
-   | json_pp
+      -X PUT \
+      -H "Content-Type: application/json" \
+      -d "{
+               \"status\": \"4 = done\"
+         }" \
+      localhost:5000/api/v1/issues/${ISSUE_3_ID} \
+      | json_pp
 
    # ...
    < HTTP/1.1 200 OK
@@ -457,9 +477,9 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X DELETE \
-   localhost:5000/api/v1/issues/17 \
-   | json_pp
+      -X DELETE \
+      localhost:5000/api/v1/issues/17 \
+      | json_pp
 
    # ...
    < HTTP/1.1 400 Bad Request
@@ -471,9 +491,9 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X DELETE \
-   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-   | json_pp
+      -X DELETE \
+      localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+      | json_pp
 
    # ...
    < HTTP/1.1 404 Not Found
@@ -485,8 +505,8 @@ in it, issue the following requests to the HTTP server:
 
    ```bash
    curl -v \
-   -X DELETE \
-   localhost:5000/api/v1/issues/${ISSUE_3_ID}
+      -X DELETE \
+      localhost:5000/api/v1/issues/${ISSUE_3_ID}
 
    # ...
    < HTTP/1.1 204 No Content

--- a/README.md
+++ b/README.md
@@ -201,499 +201,510 @@ in it, issue the following requests to the HTTP server:
 
 
 
-- create one
+create one
 
-   ```bash
-   curl -v \
-      -X POST \
-      -H "Content-Type: application/json" \
-      -d "{
-               \"status\": \"1 = backlog\"
-         }" \
-      localhost:5000/api/v1/issues \
-      | json_pp
+```bash
+curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"1 = backlog\"
+   }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-   # ...
-   < HTTP/1.1 400 Bad Request
-   # ...
-   {
-      "message" : "Unable to create a new issue."
-   }
-   ```
+# ...
+< HTTP/1.1 400 Bad Request
+# ...
+{
+   "message" : "Unable to create a new issue."
+}
+```
 
-   ```bash
-   curl -v \
-      -X POST \
-      -H "Content-Type: application/json" \
-      -d "{
-               \"status\": \"1 = backlog\",
-               \"deadline\": \"2024-08-19T09:00:00.000Z\",
-               \"epic\": \"backend\",
-               \"description\": \"containerize the backend\"
-         }" \
-      localhost:5000/api/v1/issues \
-      | json_pp
+```bash
+curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"1 = backlog\",
+      \"deadline\": \"2024-08-19T09:00:00.000Z\",
+      \"epic\": \"backend\",
+      \"description\": \"containerize the backend\"
+   }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-   # ...
-   < HTTP/1.1 201 Created
-   # ...
-   {
-      "__v" : 0,
-      "_id" : "66c2dbf2d0d5b26a9bdfbc9f",
-      "createdAt" : "2024-08-19T05:45:22.243Z",
-      "deadline" : "2024-08-19T09:00:00.000Z",
-      "description" : "containerize the backend",
-      "epic" : "backend",
-      "status" : "1 = backlog"
-   }
-   ```
+# ...
+< HTTP/1.1 201 Created
+# ...
+{
+   "__v" : 0,
+   "_id" : "66d34ee97d5c88082550469d",
+   "createdAt" : "2024-08-31T17:12:09.320Z",
+   "deadline" : "2024-08-19T09:00:00.000Z",
+   "description" : "containerize the backend",
+   "epic" : "backend",
+   "status" : "1 = backlog"
+}
+```
 
-   ```bash
-   curl -v \
-      -X POST \
-      -H "Content-Type: application/json" \
-      -d "{
-               \"status\": \"1 = backlog\",
-               \"deadline\": \"2024-08-28T19:45:08.246Z\",
-               \"epic\": \"backend\",
-               \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
-         }" \
-      localhost:5000/api/v1/issues \
-      | json_pp
+```bash
+curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"2 = selected\",
+      \"deadline\": \"2024-08-28T19:45:08.246Z\",
+      \"epic\": \"backend\",
+      \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
+   }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-   # ...
-   < HTTP/1.1 201 Created
-   # ...
-   ```
+# ...
+< HTTP/1.1 201 Created
+# ...
+```
 
-   ```bash
-   curl -v \
-      -X POST \
-      -H "Content-Type: application/json" \
-      -d "{
-               \"status\": \"1 = backlog\",
-               \"deadline\": \"2024-08-28T19:45:24.081Z\",
-               \"epic\": \"frontend\",
-               \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
-         }" \
-      localhost:5000/api/v1/issues \
-      | json_pp
+```bash
+curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"3 = in progress\",
+      \"deadline\": \"2024-08-28T19:45:24.081Z\",
+      \"epic\": \"frontend\",
+      \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
+   }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-   # ...
-   < HTTP/1.1 201 Created
-   # ...
-   ```
+# ...
+< HTTP/1.1 201 Created
+# ...
+```
 
-   ```bash
-   export ISSUE_3_ID=<the-_id-present-in-the-preceding-HTTP-response>
+```bash
+export ISSUE_3_ID=<the-_id-present-in-the-preceding-HTTP-response>
 
-   export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_3_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
-   ```
+export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_3_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
+```
 
 
 
-- retrieve multiple
+retrieve multiple
 
-   ```bash
-   curl -v \
-      localhost:5000/api/v1/issues \
-      | json_pp
+```bash
+curl -v \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "meta" : {
-         "curr" : "/api/v1/issues?perPage=100&page=1",
-         "next" : null,
-         "prev" : null,
-         "total" : 3
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "meta" : {
+      "curr" : "/api/v1/issues?perPage=100&page=1",
+      "next" : null,
+      "prev" : null,
+      "total" : 3
+   },
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66d34ee97d5c88082550469d",
+         "createdAt" : "2024-08-31T17:12:09.320Z",
+         "deadline" : "2024-08-19T09:00:00.000Z",
+         "description" : "containerize the backend",
+         "epic" : "backend",
+         "status" : "1 = backlog"
       },
-      "resources" : [
-         {
-            "__v" : 0,
-            "_id" : "66cf7dbbc96812bec9925392",
-            "createdAt" : "2024-08-28T19:42:51.501Z",
-            "deadline" : "2024-08-19T09:00:00.000Z",
-            "description" : "containerize the backend",
-            "epic" : "backend",
-            "status" : "3 = in progress"
-         },
-         {
-            "__v" : 0,
-            "_id" : "66cf7eb7c96812bec9925394",
-            "createdAt" : "2024-08-28T19:47:03.691Z",
-            "deadline" : "2024-08-28T19:45:08.246Z",
-            "description" : "convert the `epic` field to a `parentId` field",
-            "epic" : "backend",
-            "status" : "1 = backlog"
-         },
-         {
-            "__v" : 0,
-            "_id" : "66cf7edfc96812bec9925396",
-            "createdAt" : "2024-08-28T19:47:43.611Z",
-            "deadline" : "2024-08-28T19:45:24.081Z",
-            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-            "epic" : "frontend",
-            "status" : "2 = selected"
-         }
-      ]
-   }
-   ```
-
-   ```bash
-   curl -v \
-      localhost:5000/api/v1/issues?epic=frontend \
-      | json_pp
-
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "meta" : {
-         "curr" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
-         "next" : null,
-         "prev" : null,
-         "total" : 3
+      {
+         "__v" : 0,
+         "_id" : "66d34f007d5c88082550469f",
+         "createdAt" : "2024-08-31T17:12:32.817Z",
+         "deadline" : "2024-08-28T19:45:08.246Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "epic" : "backend",
+         "status" : "2 = selected"
       },
-      "resources" : [
-         {
-            "__v" : 0,
-            "_id" : "66cf7edfc96812bec9925396",
-            "createdAt" : "2024-08-28T19:47:43.611Z",
-            "deadline" : "2024-08-28T19:45:24.081Z",
-            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-            "epic" : "frontend",
-            "status" : "2 = selected"
-         }
-      ]
-   }
-   ```
+      {
+         "__v" : 0,
+         "_id" : "66d34f1e7d5c8808255046a1",
+         "createdAt" : "2024-08-31T17:13:02.467Z",
+         "deadline" : "2024-08-28T19:45:24.081Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
+         "status" : "3 = in progress"
+      }
+   ]
+}
+```
 
-   <u>TODO: (2024/08/29; 11:04)</u> consider whether this application needs to support Mongoose operators via URL query strings
-   ```bash
-   curl -v \
-      'localhost:5000/api/v1/issues?deadline\[lte\]=2024-08-23' \
-      | json_pp
-   
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "resources" : [
-         {
-            "__v" : 0,
-            "_id" : "66cf7dbbc96812bec9925392",
-            "createdAt" : "2024-08-28T19:42:51.501Z",
-            "deadline" : "2024-08-19T09:00:00.000Z",
-            "description" : "containerize the backend",
-            "epic" : "backend",
-            "status" : "3 = in progress"
-         }
-      ]
-   }
-   ```
+<u>TODO: (2024/08/31, 19:04) the `total` returned in the response to the next request is incorrect - write a test, which catches this bug, and fix the request-handling function</u>
 
-   ```bash
-   curl -v \
-      'localhost:5000/api/v1/issues?select=description,status' \
-      | json_pp
-   
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "meta" : {
-         "curr" : "/api/v1/issues?select=description%2Cstatus&perPage=100&page=1",
-         "next" : null,
-         "prev" : null,
-         "total" : 3
+```bash
+curl -v \
+   localhost:5000/api/v1/issues?epic=frontend \
+   | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "meta" : {
+      "curr" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
+      "next" : null,
+      "prev" : null,
+      "total" : 3
+   },
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66d34f1e7d5c8808255046a1",
+         "createdAt" : "2024-08-31T17:13:02.467Z",
+         "deadline" : "2024-08-28T19:45:24.081Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
+         "status" : "3 = in progress"
+      }
+   ]
+}
+```
+
+<u>TODO: (2024/08/29; 11:04)</u> consider whether this application needs to support Mongoose operators via URL query strings
+
+```bash
+curl -v \
+   'localhost:5000/api/v1/issues?deadline\[lte\]=2024-08-23' \
+   | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "meta" : {
+      "curr" : "/api/v1/issues?deadline=%5Bobject+Object%5D&perPage=100&page=1",
+      "next" : null,
+      "prev" : null,
+      "total" : 3
+   },
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66d34ee97d5c88082550469d",
+         "createdAt" : "2024-08-31T17:12:09.320Z",
+         "deadline" : "2024-08-19T09:00:00.000Z",
+         "description" : "containerize the backend",
+         "epic" : "backend",
+         "status" : "1 = backlog"
+      }
+   ]
+}
+```
+
+```bash
+curl -v \
+   'localhost:5000/api/v1/issues?select=description,status' \
+   | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "meta" : {
+      "curr" : "/api/v1/issues?select=description%2Cstatus&perPage=100&page=1",
+      "next" : null,
+      "prev" : null,
+      "total" : 3
+   },
+   "resources" : [
+      {
+         "_id" : "66d34ee97d5c88082550469d",
+         "description" : "containerize the backend",
+         "status" : "1 = backlog"
       },
-      "resources" : [
-         {
-            "_id" : "66cf7dbbc96812bec9925392",
-            "description" : "containerize the backend",
-            "status" : "3 = in progress"
-         },
-         {
-            "_id" : "66cf7eb7c96812bec9925394",
-            "description" : "convert the `epic` field to a `parentId` field",
-            "status" : "1 = backlog"
-         },
-         {
-            "_id" : "66cf7edfc96812bec9925396",
-            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-            "status" : "2 = selected"
-         }
-      ]
-   }
-   ```
-
-   ```bash
-   curl -v \
-      'localhost:5000/api/v1/issues?sort=-status' \
-      | json_pp
-
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "meta" : {
-         "curr" : "/api/v1/issues?sort=-status&perPage=100&page=1",
-         "next" : null,
-         "prev" : null,
-         "total" : 3
+      {
+         "_id" : "66d34f007d5c88082550469f",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "status" : "2 = selected"
       },
-      "resources" : [
-         {
-            "__v" : 0,
-            "_id" : "66cf7dbbc96812bec9925392",
-            "createdAt" : "2024-08-28T19:42:51.501Z",
-            "deadline" : "2024-08-19T09:00:00.000Z",
-            "description" : "containerize the backend",
-            "epic" : "backend",
-            "status" : "3 = in progress"
-         },
-         {
-            "__v" : 0,
-            "_id" : "66cf7edfc96812bec9925396",
-            "createdAt" : "2024-08-28T19:47:43.611Z",
-            "deadline" : "2024-08-28T19:45:24.081Z",
-            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-            "epic" : "frontend",
-            "status" : "2 = selected"
-         },
-         {
-            "__v" : 0,
-            "_id" : "66cf7eb7c96812bec9925394",
-            "createdAt" : "2024-08-28T19:47:03.691Z",
-            "deadline" : "2024-08-28T19:45:08.246Z",
-            "description" : "convert the `epic` field to a `parentId` field",
-            "epic" : "backend",
-            "status" : "1 = backlog"
-         }
-      ]
-   }
+      {
+         "_id" : "66d34f1e7d5c8808255046a1",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "status" : "3 = in progress"
+      }
+   ]
+}
+```
 
-   curl -v \
-      'localhost:5000/api/v1/issues?sort=status' \
-      | json_pp
-   
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "meta" : {
-         "curr" : "/api/v1/issues?sort=status&perPage=100&page=1",
-         "next" : null,
-         "prev" : null,
-         "total" : 3
+```bash
+curl -v \
+   'localhost:5000/api/v1/issues?sort=-status' \
+   | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "meta" : {
+      "curr" : "/api/v1/issues?sort=-status&perPage=100&page=1",
+      "next" : null,
+      "prev" : null,
+      "total" : 3
+   },
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66d34f1e7d5c8808255046a1",
+         "createdAt" : "2024-08-31T17:13:02.467Z",
+         "deadline" : "2024-08-28T19:45:24.081Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
+         "status" : "3 = in progress"
       },
-      "resources" : [
-         {
-            "__v" : 0,
-            "_id" : "66cf7eb7c96812bec9925394",
-            "createdAt" : "2024-08-28T19:47:03.691Z",
-            "deadline" : "2024-08-28T19:45:08.246Z",
-            "description" : "convert the `epic` field to a `parentId` field",
-            "epic" : "backend",
-            "status" : "1 = backlog"
-         },
-         {
-            "__v" : 0,
-            "_id" : "66cf7edfc96812bec9925396",
-            "createdAt" : "2024-08-28T19:47:43.611Z",
-            "deadline" : "2024-08-28T19:45:24.081Z",
-            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-            "epic" : "frontend",
-            "status" : "2 = selected"
-         },
-         {
-            "__v" : 0,
-            "_id" : "66cf7dbbc96812bec9925392",
-            "createdAt" : "2024-08-28T19:42:51.501Z",
-            "deadline" : "2024-08-19T09:00:00.000Z",
-            "description" : "containerize the backend",
-            "epic" : "backend",
-            "status" : "3 = in progress"
-         }
-      ]
-   }
-   ```
-
-   ```bash
-   curl -v \
-      'localhost:5000/api/v1/issues?perPage=2&page=2' \
-      | json_pp
-
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "meta" : {
-         "curr" : "/api/v1/issues?perPage=2&page=2",
-         "next" : null,
-         "prev" : "/api/v1/issues?perPage=2&page=1",
-         "total" : 3
+      {
+         "__v" : 0,
+         "_id" : "66d34f007d5c88082550469f",
+         "createdAt" : "2024-08-31T17:12:32.817Z",
+         "deadline" : "2024-08-28T19:45:08.246Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "epic" : "backend",
+         "status" : "2 = selected"
       },
-      "resources" : [
-         {
-            "__v" : 0,
-            "_id" : "66cf7edfc96812bec9925396",
-            "createdAt" : "2024-08-28T19:47:43.611Z",
-            "deadline" : "2024-08-28T19:45:24.081Z",
-            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-            "epic" : "frontend",
-            "status" : "2 = selected"
-         }
-      ]
-   }
-   ```
+      {
+         "__v" : 0,
+         "_id" : "66d34ee97d5c88082550469d",
+         "createdAt" : "2024-08-31T17:12:09.320Z",
+         "deadline" : "2024-08-19T09:00:00.000Z",
+         "description" : "containerize the backend",
+         "epic" : "backend",
+         "status" : "1 = backlog"
+      }
+   ]
+}
 
 
 
-- retrieve one
+curl -v \
+   'localhost:5000/api/v1/issues?sort=status' \
+   | json_pp
 
-   ```bash
-   curl -v \
-      localhost:5000/api/v1/issues/17 \
-      | json_pp
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "meta" : {
+      "curr" : "/api/v1/issues?sort=status&perPage=100&page=1",
+      "next" : null,
+      "prev" : null,
+      "total" : 3
+   },
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66d34ee97d5c88082550469d",
+         "createdAt" : "2024-08-31T17:12:09.320Z",
+         "deadline" : "2024-08-19T09:00:00.000Z",
+         "description" : "containerize the backend",
+         "epic" : "backend",
+         "status" : "1 = backlog"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d34f007d5c88082550469f",
+         "createdAt" : "2024-08-31T17:12:32.817Z",
+         "deadline" : "2024-08-28T19:45:08.246Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "epic" : "backend",
+         "status" : "2 = selected"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d34f1e7d5c8808255046a1",
+         "createdAt" : "2024-08-31T17:13:02.467Z",
+         "deadline" : "2024-08-28T19:45:24.081Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
+         "status" : "3 = in progress"
+      }
+   ]
+}
+```
 
-   # ...
-   < HTTP/1.1 400 Bad Request
-   # ...
-   {
-      "message" : "Invalid ID provided"
-   }
-   ```
+```bash
+curl -v \
+   'localhost:5000/api/v1/issues?perPage=2&page=2' \
+   | json_pp
 
-   ```bash
-   curl -v \
-      localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-      | json_pp
-
-   # ...
-   < HTTP/1.1 404 Not Found
-   # ...
-   {
-      "message" : "Resource not found"
-   }
-   ```
-
-   ```bash
-   curl -v \
-      localhost:5000/api/v1/issues/${ISSUE_3_ID} \
-      | json_pp
-
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "__v" : 0,
-      "_id" : "66c2dbf2d0d5b26a9bdfbc9f",
-      "createdAt" : "2024-08-19T05:45:22.243Z",
-      "deadline" : "2024-08-19T09:00:00.000Z",
-      "description" : "containerize the backend",
-      "epic" : "backend",
-      "status" : "1 = backlog"
-   }
-   ```
-
-
-
-- update one
-
-   ```bash
-   curl -v \
-      -X PUT \
-      localhost:5000/api/v1/issues/17 \
-      | json_pp
-
-   # ...
-   < HTTP/1.1 400 Bad Request
-   # ...
-   {
-      "message" : "Invalid ID provided"
-   }
-   ```
-
-   ```bash
-   curl -v \
-      -X PUT \
-      localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-      | json_pp
-
-   # ...
-   < HTTP/1.1 404 Not Found
-   # ...
-   {
-      "message" : "Resource not found"
-   }
-   ```
-
-   ```bash
-   curl -v \
-      -X PUT \
-      -H "Content-Type: application/json" \
-      -d "{
-               \"status\": \"4 = done\"
-         }" \
-      localhost:5000/api/v1/issues/${ISSUE_3_ID} \
-      | json_pp
-
-   # ...
-   < HTTP/1.1 200 OK
-   # ...
-   {
-      "__v" : 0,
-      "_id" : "66c4f458e3788fc8e79d0c89",
-      "createdAt" : "2024-08-20T19:54:00.804Z",
-      "deadline" : "2024-08-19T09:00:00.000Z",
-      "description" : "containerize the backend",
-      "epic" : "backend",
-      "status" : "4 = done"
-   }
-   ```
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "meta" : {
+      "curr" : "/api/v1/issues?perPage=2&page=2",
+      "next" : null,
+      "prev" : "/api/v1/issues?perPage=2&page=1",
+      "total" : 3
+   },
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66d34f1e7d5c8808255046a1",
+         "createdAt" : "2024-08-31T17:13:02.467Z",
+         "deadline" : "2024-08-28T19:45:24.081Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
+         "status" : "3 = in progress"
+      }
+   ]
+}
+```
 
 
 
-- delete one
+retrieve one
 
-   ```bash
-   curl -v \
-      -X DELETE \
-      localhost:5000/api/v1/issues/17 \
-      | json_pp
+```bash
+curl -v \
+   localhost:5000/api/v1/issues/17 \
+   | json_pp
 
-   # ...
-   < HTTP/1.1 400 Bad Request
-   # ...
-   {
-      "message" : "Invalid ID provided"
-   }
-   ```
+# ...
+< HTTP/1.1 400 Bad Request
+# ...
+{
+   "message" : "Invalid ID provided"
+}
+```
 
-   ```bash
-   curl -v \
-      -X DELETE \
-      localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-      | json_pp
+```bash
+curl -v \
+   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+   | json_pp
 
-   # ...
-   < HTTP/1.1 404 Not Found
-   # ...
-   {
-      "message" : "Resource not found"
-   }
-   ```
+# ...
+< HTTP/1.1 404 Not Found
+# ...
+{
+   "message" : "Resource not found"
+}
+```
 
-   ```bash
-   curl -v \
-      -X DELETE \
-      localhost:5000/api/v1/issues/${ISSUE_3_ID}
+```bash
+curl -v \
+   localhost:5000/api/v1/issues/${ISSUE_3_ID} \
+   | json_pp
 
-   # ...
-   < HTTP/1.1 204 No Content
-   # ...
-   # The body of the HTTP response is empty.
-   ```
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "__v" : 0,
+   "_id" : "66d34f1e7d5c8808255046a1",
+   "createdAt" : "2024-08-31T17:13:02.467Z",
+   "deadline" : "2024-08-28T19:45:24.081Z",
+   "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+   "epic" : "frontend",
+   "status" : "3 = in progress"
+}
+```
+
+
+
+update one
+
+```bash
+curl -v \
+   -X PUT \
+   localhost:5000/api/v1/issues/17 \
+   | json_pp
+
+# ...
+< HTTP/1.1 400 Bad Request
+# ...
+{
+   "message" : "Invalid ID provided"
+}
+```
+
+```bash
+curl -v \
+   -X PUT \
+   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+   | json_pp
+
+# ...
+< HTTP/1.1 404 Not Found
+# ...
+{
+   "message" : "Resource not found"
+}
+```
+
+```bash
+curl -v \
+   -X PUT \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"4 = done\"
+   }" \
+   localhost:5000/api/v1/issues/${ISSUE_3_ID} \
+   | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "__v" : 0,
+   "_id" : "66d34f1e7d5c8808255046a1",
+   "createdAt" : "2024-08-31T17:13:02.467Z",
+   "deadline" : "2024-08-28T19:45:24.081Z",
+   "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+   "epic" : "frontend",
+   "status" : "4 = done"
+}
+```
+
+
+
+delete one
+
+```bash
+curl -v \
+   -X DELETE \
+   localhost:5000/api/v1/issues/17 \
+   | json_pp
+
+# ...
+< HTTP/1.1 400 Bad Request
+# ...
+{
+   "message" : "Invalid ID provided"
+}
+```
+
+```bash
+curl -v \
+   -X DELETE \
+   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+   | json_pp
+
+# ...
+< HTTP/1.1 404 Not Found
+# ...
+{
+   "message" : "Resource not found"
+}
+```
+
+```bash
+curl -v \
+   -X DELETE \
+   localhost:5000/api/v1/issues/${ISSUE_3_ID}
+
+# ...
+< HTTP/1.1 204 No Content
+# ...
+# The body of the HTTP response is empty.
+```

--- a/README.md
+++ b/README.md
@@ -226,35 +226,8 @@ curl -v \
    -X POST \
    -H "Content-Type: application/json" \
    -d "{
-      \"status\": \"1 = backlog\",
-      \"deadline\": \"2024-08-19T09:00:00.000Z\",
-      \"epic\": \"backend\",
-      \"description\": \"containerize the backend\"
-   }" \
-   localhost:5000/api/v1/issues \
-   | json_pp
-
-# ...
-< HTTP/1.1 201 Created
-# ...
-{
-   "__v" : 0,
-   "_id" : "66d34ee97d5c88082550469d",
-   "createdAt" : "2024-08-31T17:12:09.320Z",
-   "deadline" : "2024-08-19T09:00:00.000Z",
-   "description" : "containerize the backend",
-   "epic" : "backend",
-   "status" : "1 = backlog"
-}
-```
-
-```bash
-curl -v \
-   -X POST \
-   -H "Content-Type: application/json" \
-   -d "{
-      \"status\": \"2 = selected\",
-      \"deadline\": \"2024-08-28T19:45:08.246Z\",
+      \"status\": \"3 = in progress\",
+      \"deadline\": \"2024-08-31T21:08:36.367Z\",
       \"epic\": \"backend\",
       \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
    }" \
@@ -264,17 +237,24 @@ curl -v \
 # ...
 < HTTP/1.1 201 Created
 # ...
+{
+   "__v" : 0,
+   "_id" : "66d3949e139d0bb7b82243ae",
+   "createdAt" : "2024-08-31T22:09:34.087Z",
+   "deadline" : "2024-08-31T21:08:36.367Z",
+   "description" : "convert the `epic` field to a `parentId` field",
+   "epic" : "backend",
+   "status" : "3 = in progress"
+}
 ```
-
-<u>TODO: (2024/08/31, 19:20) swap the order of the last 2 HTTP requests ("and their statuses")</u>
 
 ```bash
 curl -v \
    -X POST \
    -H "Content-Type: application/json" \
    -d "{
-      \"status\": \"3 = in progress\",
-      \"deadline\": \"2024-08-28T19:45:24.081Z\",
+      \"status\": \"1 = backlog\",
+      \"deadline\": \"2024-08-31T22:08:36.367Z\",
       \"epic\": \"frontend\",
       \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
    }" \
@@ -285,6 +265,26 @@ curl -v \
 < HTTP/1.1 201 Created
 # ...
 ```
+
+```bash
+curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"2 = selected\",
+      \"deadline\": \"2024-08-31T23:08:36.367Z\",
+      \"epic\": \"backend\",
+      \"description\": \"containerize the backend\"
+   }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
+
+# ...
+< HTTP/1.1 201 Created
+# ...
+```
+
+
 
 ```bash
 export ISSUE_3_ID=<the-_id-present-in-the-preceding-HTTP-response>
@@ -314,36 +314,34 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d34ee97d5c88082550469d",
-         "createdAt" : "2024-08-31T17:12:09.320Z",
-         "deadline" : "2024-08-19T09:00:00.000Z",
-         "description" : "containerize the backend",
+         "_id" : "66d3949e139d0bb7b82243ae",
+         "createdAt" : "2024-08-31T22:09:34.087Z",
+         "deadline" : "2024-08-31T21:08:36.367Z",
+         "description" : "convert the `epic` field to a `parentId` field",
          "epic" : "backend",
+         "status" : "3 = in progress"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d394b1139d0bb7b82243b0",
+         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66d34f007d5c88082550469f",
-         "createdAt" : "2024-08-31T17:12:32.817Z",
-         "deadline" : "2024-08-28T19:45:08.246Z",
-         "description" : "convert the `epic` field to a `parentId` field",
+         "_id" : "66d394d3139d0bb7b82243b2",
+         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "deadline" : "2024-08-31T23:08:36.367Z",
+         "description" : "containerize the backend",
          "epic" : "backend",
          "status" : "2 = selected"
-      },
-      {
-         "__v" : 0,
-         "_id" : "66d34f1e7d5c8808255046a1",
-         "createdAt" : "2024-08-31T17:13:02.467Z",
-         "deadline" : "2024-08-28T19:45:24.081Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
-         "status" : "3 = in progress"
       }
    ]
 }
 ```
-
-<u>TODO: (2024/08/31, 19:04) the `total` returned in the response to the next request is incorrect - that is a bug; the commit introducing this line also introduces a test, which catches the bug</u>
 
 ```bash
 curl -v \
@@ -358,17 +356,17 @@ curl -v \
       "curr" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
       "next" : null,
       "prev" : null,
-      "total" : 3
+      "total" : 1
    },
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d34f1e7d5c8808255046a1",
-         "createdAt" : "2024-08-31T17:13:02.467Z",
-         "deadline" : "2024-08-28T19:45:24.081Z",
+         "_id" : "66d394b1139d0bb7b82243b0",
+         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "epic" : "frontend",
-         "status" : "3 = in progress"
+         "status" : "1 = backlog"
       }
    ]
 }
@@ -378,7 +376,7 @@ curl -v \
 
 ```bash
 curl -v \
-   'localhost:5000/api/v1/issues?deadline\[lte\]=2024-08-23' \
+   'localhost:5000/api/v1/issues?status\[lt\]=3' \
    | json_pp
 
 # ...
@@ -386,20 +384,29 @@ curl -v \
 # ...
 {
    "meta" : {
-      "curr" : "/api/v1/issues?deadline=%5Bobject+Object%5D&perPage=100&page=1",
+      "curr" : "/api/v1/issues?status=%5Bobject+Object%5D&perPage=100&page=1",
       "next" : null,
       "prev" : null,
-      "total" : 3
+      "total" : 2
    },
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d34ee97d5c88082550469d",
-         "createdAt" : "2024-08-31T17:12:09.320Z",
-         "deadline" : "2024-08-19T09:00:00.000Z",
+         "_id" : "66d394b1139d0bb7b82243b0",
+         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
+         "status" : "1 = backlog"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d394d3139d0bb7b82243b2",
+         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
          "epic" : "backend",
-         "status" : "1 = backlog"
+         "status" : "2 = selected"
       }
    ]
 }
@@ -422,19 +429,19 @@ curl -v \
    },
    "resources" : [
       {
-         "_id" : "66d34ee97d5c88082550469d",
-         "description" : "containerize the backend",
+         "_id" : "66d3949e139d0bb7b82243ae",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "status" : "3 = in progress"
+      },
+      {
+         "_id" : "66d394b1139d0bb7b82243b0",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "status" : "1 = backlog"
       },
       {
-         "_id" : "66d34f007d5c88082550469f",
-         "description" : "convert the `epic` field to a `parentId` field",
+         "_id" : "66d394d3139d0bb7b82243b2",
+         "description" : "containerize the backend",
          "status" : "2 = selected"
-      },
-      {
-         "_id" : "66d34f1e7d5c8808255046a1",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "status" : "3 = in progress"
       }
    ]
 }
@@ -458,29 +465,29 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d34f1e7d5c8808255046a1",
-         "createdAt" : "2024-08-31T17:13:02.467Z",
-         "deadline" : "2024-08-28T19:45:24.081Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
+         "_id" : "66d3949e139d0bb7b82243ae",
+         "createdAt" : "2024-08-31T22:09:34.087Z",
+         "deadline" : "2024-08-31T21:08:36.367Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "epic" : "backend",
          "status" : "3 = in progress"
       },
       {
          "__v" : 0,
-         "_id" : "66d34f007d5c88082550469f",
-         "createdAt" : "2024-08-31T17:12:32.817Z",
-         "deadline" : "2024-08-28T19:45:08.246Z",
-         "description" : "convert the `epic` field to a `parentId` field",
+         "_id" : "66d394d3139d0bb7b82243b2",
+         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "deadline" : "2024-08-31T23:08:36.367Z",
+         "description" : "containerize the backend",
          "epic" : "backend",
          "status" : "2 = selected"
       },
       {
          "__v" : 0,
-         "_id" : "66d34ee97d5c88082550469d",
-         "createdAt" : "2024-08-31T17:12:09.320Z",
-         "deadline" : "2024-08-19T09:00:00.000Z",
-         "description" : "containerize the backend",
-         "epic" : "backend",
+         "_id" : "66d394b1139d0bb7b82243b0",
+         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
          "status" : "1 = backlog"
       }
    ]
@@ -505,29 +512,29 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d34ee97d5c88082550469d",
-         "createdAt" : "2024-08-31T17:12:09.320Z",
-         "deadline" : "2024-08-19T09:00:00.000Z",
-         "description" : "containerize the backend",
-         "epic" : "backend",
+         "_id" : "66d394b1139d0bb7b82243b0",
+         "createdAt" : "2024-08-31T22:09:53.919Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "epic" : "frontend",
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66d34f007d5c88082550469f",
-         "createdAt" : "2024-08-31T17:12:32.817Z",
-         "deadline" : "2024-08-28T19:45:08.246Z",
-         "description" : "convert the `epic` field to a `parentId` field",
+         "_id" : "66d394d3139d0bb7b82243b2",
+         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "deadline" : "2024-08-31T23:08:36.367Z",
+         "description" : "containerize the backend",
          "epic" : "backend",
          "status" : "2 = selected"
       },
       {
          "__v" : 0,
-         "_id" : "66d34f1e7d5c8808255046a1",
-         "createdAt" : "2024-08-31T17:13:02.467Z",
-         "deadline" : "2024-08-28T19:45:24.081Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
+         "_id" : "66d3949e139d0bb7b82243ae",
+         "createdAt" : "2024-08-31T22:09:34.087Z",
+         "deadline" : "2024-08-31T21:08:36.367Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "epic" : "backend",
          "status" : "3 = in progress"
       }
    ]
@@ -552,12 +559,12 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d34f1e7d5c8808255046a1",
-         "createdAt" : "2024-08-31T17:13:02.467Z",
-         "deadline" : "2024-08-28T19:45:24.081Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
-         "status" : "3 = in progress"
+         "_id" : "66d394d3139d0bb7b82243b2",
+         "createdAt" : "2024-08-31T22:10:27.679Z",
+         "deadline" : "2024-08-31T23:08:36.367Z",
+         "description" : "containerize the backend",
+         "epic" : "backend",
+         "status" : "2 = selected"
       }
    ]
 }
@@ -603,12 +610,12 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d34f1e7d5c8808255046a1",
-   "createdAt" : "2024-08-31T17:13:02.467Z",
-   "deadline" : "2024-08-28T19:45:24.081Z",
-   "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-   "epic" : "frontend",
-   "status" : "3 = in progress"
+   "_id" : "66d394d3139d0bb7b82243b2",
+   "createdAt" : "2024-08-31T22:10:27.679Z",
+   "deadline" : "2024-08-31T23:08:36.367Z",
+   "description" : "containerize the backend",
+   "epic" : "backend",
+   "status" : "2 = selected"
 }
 ```
 
@@ -649,7 +656,7 @@ curl -v \
    -X PUT \
    -H "Content-Type: application/json" \
    -d "{
-      \"status\": \"4 = done\"
+      \"status\": \"3 = in progress\"
    }" \
    localhost:5000/api/v1/issues/${ISSUE_3_ID} \
    | json_pp
@@ -659,12 +666,12 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d34f1e7d5c8808255046a1",
-   "createdAt" : "2024-08-31T17:13:02.467Z",
-   "deadline" : "2024-08-28T19:45:24.081Z",
-   "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-   "epic" : "frontend",
-   "status" : "4 = done"
+   "_id" : "66d394d3139d0bb7b82243b2",
+   "createdAt" : "2024-08-31T22:10:27.679Z",
+   "deadline" : "2024-08-31T23:08:36.367Z",
+   "description" : "containerize the backend",
+   "epic" : "backend",
+   "status" : "3 = in progress"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,297 +189,307 @@ in it, issue the following requests to the HTTP server:
 
 
 
-```bash
-curl -v \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d "{
-         \"status\": \"1 = backlog\"
-    }" \
-  localhost:5000/api/v1/issues \
-  | json_pp
+- create one
 
-# ...
-< HTTP/1.1 400 Bad Request
-# ...
-{
-   "message" : "Unable to create a new issue."
-}
-```
+   ```bash
+   curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+            \"status\": \"1 = backlog\"
+      }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-```bash
-curl -v \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d "{
-         \"status\": \"1 = backlog\",
-         \"deadline\": \"2024-08-19T09:00:00.000Z\",
-         \"epic\": \"backend\",
-         \"description\": \"containerize the backend\"
-    }" \
-  localhost:5000/api/v1/issues \
-  | json_pp
+   # ...
+   < HTTP/1.1 400 Bad Request
+   # ...
+   {
+      "message" : "Unable to create a new issue."
+   }
+   ```
 
-# ...
-< HTTP/1.1 201 Created
-# ...
-{
-   "__v" : 0,
-   "_id" : "66c2dbf2d0d5b26a9bdfbc9f",
-   "createdAt" : "2024-08-19T05:45:22.243Z",
-   "deadline" : "2024-08-19T09:00:00.000Z",
-   "description" : "containerize the backend",
-   "epic" : "backend",
-   "status" : "1 = backlog"
-}
-```
+   ```bash
+   curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+            \"status\": \"1 = backlog\",
+            \"deadline\": \"2024-08-19T09:00:00.000Z\",
+            \"epic\": \"backend\",
+            \"description\": \"containerize the backend\"
+      }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-```bash
-curl -v \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d "{
-         \"status\": \"1 = backlog\",
-         \"deadline\": \"2024-08-28T19:45:08.246Z\",
-         \"epic\": \"backend\",
-         \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
-    }" \
-  localhost:5000/api/v1/issues \
-  | json_pp
+   # ...
+   < HTTP/1.1 201 Created
+   # ...
+   {
+      "__v" : 0,
+      "_id" : "66c2dbf2d0d5b26a9bdfbc9f",
+      "createdAt" : "2024-08-19T05:45:22.243Z",
+      "deadline" : "2024-08-19T09:00:00.000Z",
+      "description" : "containerize the backend",
+      "epic" : "backend",
+      "status" : "1 = backlog"
+   }
+   ```
 
-# ...
-< HTTP/1.1 201 Created
-# ...
-```
+   ```bash
+   curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+            \"status\": \"1 = backlog\",
+            \"deadline\": \"2024-08-28T19:45:08.246Z\",
+            \"epic\": \"backend\",
+            \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
+      }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-```bash
-curl -v \
-  -X POST \
-  -H "Content-Type: application/json" \
-  -d "{
-         \"status\": \"1 = backlog\",
-         \"deadline\": \"2024-08-28T19:45:24.081Z\",
-         \"epic\": \"frontend\",
-         \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
-    }" \
-  localhost:5000/api/v1/issues \
-  | json_pp
+   # ...
+   < HTTP/1.1 201 Created
+   # ...
+   ```
 
-# ...
-< HTTP/1.1 201 Created
-# ...
-```
+   ```bash
+   curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+            \"status\": \"1 = backlog\",
+            \"deadline\": \"2024-08-28T19:45:24.081Z\",
+            \"epic\": \"frontend\",
+            \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
+      }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-```bash
-export ISSUE_3_ID=<the-_id-present-in-the-preceding-HTTP-response>
+   # ...
+   < HTTP/1.1 201 Created
+   # ...
+   ```
 
-export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_3_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
-```
+   ```bash
+   export ISSUE_3_ID=<the-_id-present-in-the-preceding-HTTP-response>
 
-
-
-```bash
-curl -v \
-  localhost:5000/api/v1/issues \
-  | json_pp
-
-# ...
-< HTTP/1.1 200 OK
-# ...
-{
-   "resources" : [
-      {
-         "__v" : 0,
-         "_id" : "66cf7dbbc96812bec9925392",
-         "createdAt" : "2024-08-28T19:42:51.501Z",
-         "deadline" : "2024-08-19T09:00:00.000Z",
-         "description" : "containerize the backend",
-         "epic" : "backend",
-         "status" : "1 = backlog"
-      },
-      {
-         "__v" : 0,
-         "_id" : "66cf7eb7c96812bec9925394",
-         "createdAt" : "2024-08-28T19:47:03.691Z",
-         "deadline" : "2024-08-28T19:45:08.246Z",
-         "description" : "convert the `epic` field to a `parentId` field",
-         "epic" : "backend",
-         "status" : "1 = backlog"
-      },
-      {
-         "__v" : 0,
-         "_id" : "66cf7edfc96812bec9925396",
-         "createdAt" : "2024-08-28T19:47:43.611Z",
-         "deadline" : "2024-08-28T19:45:24.081Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
-         "status" : "1 = backlog"
-      }
-   ]
-}
-```
-
-```bash
-curl -v \
-  localhost:5000/api/v1/issues?epic=frontend \
-  | json_pp
-
-# ...
-< HTTP/1.1 200 OK
-# ...
-{
-   "resources" : [
-      {
-         "__v" : 0,
-         "_id" : "66cf7edfc96812bec9925396",
-         "createdAt" : "2024-08-28T19:47:43.611Z",
-         "deadline" : "2024-08-28T19:45:24.081Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
-         "status" : "1 = backlog"
-      }
-   ]
-}
-```
+   export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_3_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
+   ```
 
 
 
-```bash
-curl -v \
-  localhost:5000/api/v1/issues/17 \
-  | json_pp
+- retrieve multiple
 
-# ...
-< HTTP/1.1 400 Bad Request
-# ...
-{
-   "message" : "Invalid ID provided"
-}
-```
+   ```bash
+   curl -v \
+   localhost:5000/api/v1/issues \
+   | json_pp
 
-```bash
-curl -v \
-  localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-  | json_pp
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
+   {
+      "resources" : [
+         {
+            "__v" : 0,
+            "_id" : "66cf7dbbc96812bec9925392",
+            "createdAt" : "2024-08-28T19:42:51.501Z",
+            "deadline" : "2024-08-19T09:00:00.000Z",
+            "description" : "containerize the backend",
+            "epic" : "backend",
+            "status" : "1 = backlog"
+         },
+         {
+            "__v" : 0,
+            "_id" : "66cf7eb7c96812bec9925394",
+            "createdAt" : "2024-08-28T19:47:03.691Z",
+            "deadline" : "2024-08-28T19:45:08.246Z",
+            "description" : "convert the `epic` field to a `parentId` field",
+            "epic" : "backend",
+            "status" : "1 = backlog"
+         },
+         {
+            "__v" : 0,
+            "_id" : "66cf7edfc96812bec9925396",
+            "createdAt" : "2024-08-28T19:47:43.611Z",
+            "deadline" : "2024-08-28T19:45:24.081Z",
+            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+            "epic" : "frontend",
+            "status" : "1 = backlog"
+         }
+      ]
+   }
+   ```
 
-# ...
-< HTTP/1.1 404 Not Found
-# ...
-{
-   "message" : "Resource not found"
-}
-```
+   ```bash
+   curl -v \
+   localhost:5000/api/v1/issues?epic=frontend \
+   | json_pp
 
-```bash
-curl -v \
-  localhost:5000/api/v1/issues/${ISSUE_3_ID} \
-  | json_pp
-
-# ...
-< HTTP/1.1 200 OK
-# ...
-{
-   "__v" : 0,
-   "_id" : "66c2dbf2d0d5b26a9bdfbc9f",
-   "createdAt" : "2024-08-19T05:45:22.243Z",
-   "deadline" : "2024-08-19T09:00:00.000Z",
-   "description" : "containerize the backend",
-   "epic" : "backend",
-   "status" : "1 = backlog"
-}
-```
-
-
-
-```bash
-curl -v \
-  -X PUT \
-  localhost:5000/api/v1/issues/17 \
-  | json_pp
-
-# ...
-< HTTP/1.1 400 Bad Request
-# ...
-{
-   "message" : "Invalid ID provided"
-}
-```
-
-```bash
-curl -v \
-  -X PUT \
-  localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-  | json_pp
-
-# ...
-< HTTP/1.1 404 Not Found
-# ...
-{
-   "message" : "Resource not found"
-}
-```
-
-```bash
-curl -v \
-  -X PUT \
-  -H "Content-Type: application/json" \
-  -d "{
-         \"status\": \"4 = done\"
-    }" \
-  localhost:5000/api/v1/issues/${ISSUE_3_ID} \
-  | json_pp
-
-# ...
-< HTTP/1.1 200 OK
-# ...
-{
-   "__v" : 0,
-   "_id" : "66c4f458e3788fc8e79d0c89",
-   "createdAt" : "2024-08-20T19:54:00.804Z",
-   "deadline" : "2024-08-19T09:00:00.000Z",
-   "description" : "containerize the backend",
-   "epic" : "backend",
-   "status" : "4 = done"
-}
-```
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
+   {
+      "resources" : [
+         {
+            "__v" : 0,
+            "_id" : "66cf7edfc96812bec9925396",
+            "createdAt" : "2024-08-28T19:47:43.611Z",
+            "deadline" : "2024-08-28T19:45:24.081Z",
+            "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+            "epic" : "frontend",
+            "status" : "1 = backlog"
+         }
+      ]
+   }
+   ```
 
 
 
-```bash
-curl -v \
-  -X DELETE \
-  localhost:5000/api/v1/issues/17 \
-  | json_pp
+- retrieve one
 
-# ...
-< HTTP/1.1 400 Bad Request
-# ...
-{
-   "message" : "Invalid ID provided"
-}
-```
+   ```bash
+   curl -v \
+   localhost:5000/api/v1/issues/17 \
+   | json_pp
 
-```bash
-curl -v \
-  -X DELETE \
-  localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
-  | json_pp
+   # ...
+   < HTTP/1.1 400 Bad Request
+   # ...
+   {
+      "message" : "Invalid ID provided"
+   }
+   ```
 
-# ...
-< HTTP/1.1 404 Not Found
-# ...
-{
-   "message" : "Resource not found"
-}
-```
+   ```bash
+   curl -v \
+   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+   | json_pp
 
-```bash
-curl -v \
-  -X DELETE \
-  localhost:5000/api/v1/issues/${ISSUE_3_ID}
+   # ...
+   < HTTP/1.1 404 Not Found
+   # ...
+   {
+      "message" : "Resource not found"
+   }
+   ```
 
-# ...
-< HTTP/1.1 204 No Content
-# ...
-# The body of the HTTP response is empty.
-```
+   ```bash
+   curl -v \
+   localhost:5000/api/v1/issues/${ISSUE_3_ID} \
+   | json_pp
+
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
+   {
+      "__v" : 0,
+      "_id" : "66c2dbf2d0d5b26a9bdfbc9f",
+      "createdAt" : "2024-08-19T05:45:22.243Z",
+      "deadline" : "2024-08-19T09:00:00.000Z",
+      "description" : "containerize the backend",
+      "epic" : "backend",
+      "status" : "1 = backlog"
+   }
+   ```
+
+
+
+- update one
+
+   ```bash
+   curl -v \
+   -X PUT \
+   localhost:5000/api/v1/issues/17 \
+   | json_pp
+
+   # ...
+   < HTTP/1.1 400 Bad Request
+   # ...
+   {
+      "message" : "Invalid ID provided"
+   }
+   ```
+
+   ```bash
+   curl -v \
+   -X PUT \
+   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+   | json_pp
+
+   # ...
+   < HTTP/1.1 404 Not Found
+   # ...
+   {
+      "message" : "Resource not found"
+   }
+   ```
+
+   ```bash
+   curl -v \
+   -X PUT \
+   -H "Content-Type: application/json" \
+   -d "{
+            \"status\": \"4 = done\"
+      }" \
+   localhost:5000/api/v1/issues/${ISSUE_3_ID} \
+   | json_pp
+
+   # ...
+   < HTTP/1.1 200 OK
+   # ...
+   {
+      "__v" : 0,
+      "_id" : "66c4f458e3788fc8e79d0c89",
+      "createdAt" : "2024-08-20T19:54:00.804Z",
+      "deadline" : "2024-08-19T09:00:00.000Z",
+      "description" : "containerize the backend",
+      "epic" : "backend",
+      "status" : "4 = done"
+   }
+   ```
+
+
+
+- delete one
+
+   ```bash
+   curl -v \
+   -X DELETE \
+   localhost:5000/api/v1/issues/17 \
+   | json_pp
+
+   # ...
+   < HTTP/1.1 400 Bad Request
+   # ...
+   {
+      "message" : "Invalid ID provided"
+   }
+   ```
+
+   ```bash
+   curl -v \
+   -X DELETE \
+   localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
+   | json_pp
+
+   # ...
+   < HTTP/1.1 404 Not Found
+   # ...
+   {
+      "message" : "Resource not found"
+   }
+   ```
+
+   ```bash
+   curl -v \
+   -X DELETE \
+   localhost:5000/api/v1/issues/${ISSUE_3_ID}
+
+   # ...
+   < HTTP/1.1 204 No Content
+   # ...
+   # The body of the HTTP response is empty.
+   ```

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -87,76 +87,84 @@ describe('POST /api/v1/issues', () => {
 });
 
 describe('GET /api/v1/issues', () => {
-  test('if there are no Issue resources in the MongoDB server, should return 200 and an empty list', async () => {
-    // Act.
-    const response = await request(app).get('/api/v1/issues');
+  test(
+    'if there are no Issue resources in the MongoDB server,' +
+      ' should return 200 and an empty list',
+    async () => {
+      // Act.
+      const response = await request(app).get('/api/v1/issues');
 
-    // Assert.
-    expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      meta: {
-        total: 0,
-        first: `/api/v1/issues?page=1`,
-        prev: null,
-        curr: '/api/v1/issues',
-        next: null,
-        last: `/api/v1/issues?page=1`,
-      },
-      resources: [],
-    });
-  });
-
-  test('if there are Issue resources, should return 200 and representations of the resources', async () => {
-    // Arrange.
-    const issue1 = await Issue.create({
-      status: '3 = in progress',
-      deadline: new Date('2024-08-20T21:07:45.759Z'),
-      description: 'write tests for the other request-handling functions',
-    });
-
-    const issue2 = await Issue.create({
-      status: '1 = backlog',
-      deadline: new Date('2024-08-20T21:08:31.345Z'),
-      description:
-        'switch from `const express = require(express)` to `import express from "express";"',
-    });
-
-    // Act.
-    const response = await request(app).get('/api/v1/issues');
-
-    // Assert.
-    expect(response.status).toEqual(200);
-
-    expect(response.body).toEqual({
-      meta: {
-        total: 2,
-        first: '/api/v1/issues?perPage=100&page=1',
-        prev: null,
-        curr: '/api/v1/issues?perPage=100&page=1',
-        next: null,
-        last: '/api/v1/issues?perPage=100&page=1',
-      },
-      resources: [
-        {
-          __v: expect.anything(),
-          _id: issue1._id.toString(),
-          createdAt: expect.anything(),
-          status: '3 = in progress',
-          deadline: '2024-08-20T21:07:45.759Z',
-          description: 'write tests for the other request-handling functions',
+      // Assert.
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        meta: {
+          total: 0,
+          first: `/api/v1/issues?page=1`,
+          prev: null,
+          curr: '/api/v1/issues',
+          next: null,
+          last: `/api/v1/issues?page=1`,
         },
-        {
-          __v: expect.anything(),
-          _id: issue2._id.toString(),
-          createdAt: expect.anything(),
-          status: '1 = backlog',
-          deadline: '2024-08-20T21:08:31.345Z',
-          description:
-            'switch from `const express = require(express)` to `import express from "express";"',
+        resources: [],
+      });
+    }
+  );
+
+  test(
+    'if there are Issue resources,' +
+      ' should return 200 and representations of the resources',
+    async () => {
+      // Arrange.
+      const issue1 = await Issue.create({
+        status: '3 = in progress',
+        deadline: new Date('2024-08-20T21:07:45.759Z'),
+        description: 'write tests for the other request-handling functions',
+      });
+
+      const issue2 = await Issue.create({
+        status: '1 = backlog',
+        deadline: new Date('2024-08-20T21:08:31.345Z'),
+        description:
+          'switch from `const express = require(express)` to `import express from "express";"',
+      });
+
+      // Act.
+      const response = await request(app).get('/api/v1/issues');
+
+      // Assert.
+      expect(response.status).toEqual(200);
+
+      expect(response.body).toEqual({
+        meta: {
+          total: 2,
+          first: '/api/v1/issues?perPage=100&page=1',
+          prev: null,
+          curr: '/api/v1/issues?perPage=100&page=1',
+          next: null,
+          last: '/api/v1/issues?perPage=100&page=1',
         },
-      ],
-    });
-  });
+        resources: [
+          {
+            __v: expect.anything(),
+            _id: issue1._id.toString(),
+            createdAt: expect.anything(),
+            status: '3 = in progress',
+            deadline: '2024-08-20T21:07:45.759Z',
+            description: 'write tests for the other request-handling functions',
+          },
+          {
+            __v: expect.anything(),
+            _id: issue2._id.toString(),
+            createdAt: expect.anything(),
+            status: '1 = backlog',
+            deadline: '2024-08-20T21:08:31.345Z',
+            description:
+              'switch from `const express = require(express)` to `import express from "express";"',
+          },
+        ],
+      });
+    }
+  );
 
   test(
     'if there are Issue resource' +

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -25,50 +25,6 @@ afterAll(async () => {
   await mongoMemoryServer.stop();
 });
 
-// TODO: (2024/08/25, 23:12)
-//       re-arrange the groups of automated tests
-//       to match the order in `README.md` and in `src/app.js`
-
-describe('GET /api/v1/issues/:id', () => {
-  test('if an invalid ID is provided, should return 400', async () => {
-    // Act.
-    const response = await request(app).get('/api/v1/issues/17');
-
-    // Assert.
-    expect(response.status).toEqual(400);
-    expect(response.body).toEqual({
-      message: 'Invalid ID provided',
-    });
-  });
-
-  test('if ID exists, should return 200 and corresponding issue', async () => {
-    // Arrange.
-    const deadline = new Date('2024-08-19T06:17:17.170Z');
-    const issue = await Issue.create({
-      status: '1 = backlog',
-      deadline,
-      epic: 'ease of development',
-      description: 'introduce code coverage reports in HTML format',
-    });
-
-    // Act.
-    const response = await request(app).get(`/api/v1/issues/${issue._id}`);
-
-    // Assert.
-    expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      __v: expect.anything(),
-      _id: issue.id,
-      createdAt: issue.createdAt.toISOString(),
-      status: '1 = backlog',
-      deadline: deadline.toISOString(),
-      // finishedAt: null,
-      epic: 'ease of development',
-      description: 'introduce code coverage reports in HTML format',
-    });
-  });
-});
-
 describe('POST /api/v1/issues', () => {
   test('if "status" is missing, should return 400', async () => {
     // Act.
@@ -118,6 +74,103 @@ describe('POST /api/v1/issues', () => {
       deadline: '2024-08-19T09:00:00.000Z',
       epic: 'backend',
       description: 'containerize the backend',
+    });
+  });
+});
+
+describe('GET /api/v1/issues', () => {
+  test('if there are no Issue resources in the MongoDB server, should return 200 and an empty list', async () => {
+    // Act.
+    const response = await request(app).get('/api/v1/issues');
+
+    // Assert.
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      resources: [],
+    });
+  });
+
+  test('if there are Issue resources, should return 200 and representations of the resources', async () => {
+    // Arrange.
+    const issue1 = await Issue.create({
+      status: '3 = in progress',
+      deadline: new Date('2024-08-20T21:07:45.759Z'),
+      description: 'write tests for the other request-handling functions',
+    });
+
+    const issue2 = await Issue.create({
+      status: '1 = backlog',
+      deadline: new Date('2024-08-20T21:08:31.345Z'),
+      description:
+        'switch from `const express = require(express)` to `import express from "express";"',
+    });
+
+    // Act.
+    const response = await request(app).get('/api/v1/issues');
+
+    // Assert.
+    expect(response.status).toEqual(200);
+
+    expect(response.body).toEqual({
+      resources: [
+        {
+          __v: expect.anything(),
+          _id: issue1._id.toString(),
+          createdAt: expect.anything(),
+          status: '3 = in progress',
+          deadline: '2024-08-20T21:07:45.759Z',
+          description: 'write tests for the other request-handling functions',
+        },
+        {
+          __v: expect.anything(),
+          _id: issue2._id.toString(),
+          createdAt: expect.anything(),
+          status: '1 = backlog',
+          deadline: '2024-08-20T21:08:31.345Z',
+          description:
+            'switch from `const express = require(express)` to `import express from "express";"',
+        },
+      ],
+    });
+  });
+});
+
+describe('GET /api/v1/issues/:id', () => {
+  test('if an invalid ID is provided, should return 400', async () => {
+    // Act.
+    const response = await request(app).get('/api/v1/issues/17');
+
+    // Assert.
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({
+      message: 'Invalid ID provided',
+    });
+  });
+
+  test('if ID exists, should return 200 and corresponding issue', async () => {
+    // Arrange.
+    const deadline = new Date('2024-08-19T06:17:17.170Z');
+    const issue = await Issue.create({
+      status: '1 = backlog',
+      deadline,
+      epic: 'ease of development',
+      description: 'introduce code coverage reports in HTML format',
+    });
+
+    // Act.
+    const response = await request(app).get(`/api/v1/issues/${issue._id}`);
+
+    // Assert.
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      __v: expect.anything(),
+      _id: issue.id,
+      createdAt: issue.createdAt.toISOString(),
+      status: '1 = backlog',
+      deadline: deadline.toISOString(),
+      // finishedAt: null,
+      epic: 'ease of development',
+      description: 'introduce code coverage reports in HTML format',
     });
   });
 });
@@ -193,63 +246,6 @@ describe('PUT /api/v1/issues/:id', () => {
       status: '2 = selected',
       deadline: '2024-08-20T20:38:18.162Z',
       description: 'generate code coverage reports in HTML format',
-    });
-  });
-});
-
-describe('GET /api/v1/issues', () => {
-  test('if there are no Issue resources in the MongoDB server, should return 200 and an empty list', async () => {
-    // Act.
-    const response = await request(app).get('/api/v1/issues');
-
-    // Assert.
-    expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      resources: [],
-    });
-  });
-
-  test('if there are Issue resources, should return 200 and representations of the resources', async () => {
-    // Arrange.
-    const issue1 = await Issue.create({
-      status: '3 = in progress',
-      deadline: new Date('2024-08-20T21:07:45.759Z'),
-      description: 'write tests for the other request-handling functions',
-    });
-
-    const issue2 = await Issue.create({
-      status: '1 = backlog',
-      deadline: new Date('2024-08-20T21:08:31.345Z'),
-      description:
-        'switch from `const express = require(express)` to `import express from "express";"',
-    });
-
-    // Act.
-    const response = await request(app).get('/api/v1/issues');
-
-    // Assert.
-    expect(response.status).toEqual(200);
-
-    expect(response.body).toEqual({
-      resources: [
-        {
-          __v: expect.anything(),
-          _id: issue1._id.toString(),
-          createdAt: expect.anything(),
-          status: '3 = in progress',
-          deadline: '2024-08-20T21:07:45.759Z',
-          description: 'write tests for the other request-handling functions',
-        },
-        {
-          __v: expect.anything(),
-          _id: issue2._id.toString(),
-          createdAt: expect.anything(),
-          status: '1 = backlog',
-          deadline: '2024-08-20T21:08:31.345Z',
-          description:
-            'switch from `const express = require(express)` to `import express from "express";"',
-        },
-      ],
     });
   });
 });

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -93,9 +93,11 @@ describe('GET /api/v1/issues', () => {
     expect(response.body).toEqual({
       meta: {
         total: 0,
+        first: `/api/v1/issues?page=1`,
         prev: null,
         curr: '/api/v1/issues',
         next: null,
+        last: `/api/v1/issues?page=1`,
       },
       resources: [],
     });
@@ -125,9 +127,11 @@ describe('GET /api/v1/issues', () => {
     expect(response.body).toEqual({
       meta: {
         total: 2,
+        first: '/api/v1/issues?perPage=100&page=1',
         prev: null,
         curr: '/api/v1/issues?perPage=100&page=1',
         next: null,
+        last: '/api/v1/issues?perPage=100&page=1',
       },
       resources: [
         {
@@ -188,9 +192,11 @@ describe('GET /api/v1/issues', () => {
       expect(response.body).toEqual({
         meta: {
           total: 2,
+          first: '/api/v1/issues?epic=backend&perPage=100&page=1',
           prev: null,
           curr: '/api/v1/issues?epic=backend&perPage=100&page=1',
           next: null,
+          last: '/api/v1/issues?epic=backend&perPage=100&page=1',
         },
         resources: [
           {
@@ -241,14 +247,17 @@ describe('GET /api/v1/issues', () => {
       // Assert.
       expect(response.status).toEqual(200);
 
+      const currUrl = decodeQueryStringWithinUrl(
+        '/api/v1/issues?select=status,description&perPage=100&page=1'
+      );
       expect(response.body).toEqual({
         meta: {
           total: 2,
+          first: currUrl,
           prev: null,
-          curr: decodeQueryStringWithinUrl(
-            '/api/v1/issues?select=status,description&perPage=100&page=1'
-          ),
+          curr: currUrl,
           next: null,
+          last: currUrl,
         },
         resources: [
           {
@@ -316,9 +325,11 @@ describe('GET /api/v1/issues', () => {
       expect(response1.body).toEqual({
         meta: {
           total: 2,
+          first: '/api/v1/issues?sort=-status&perPage=100&page=1',
           prev: null,
           curr: '/api/v1/issues?sort=-status&perPage=100&page=1',
           next: null,
+          last: '/api/v1/issues?sort=-status&perPage=100&page=1',
         },
         resources: expectedResources1,
       });
@@ -333,9 +344,11 @@ describe('GET /api/v1/issues', () => {
       expect(response2.body).toEqual({
         meta: {
           total: 2,
+          first: '/api/v1/issues?sort=status&perPage=100&page=1',
           prev: null,
           curr: '/api/v1/issues?sort=status&perPage=100&page=1',
           next: null,
+          last: '/api/v1/issues?sort=status&perPage=100&page=1',
         },
         resources: expectedResources2,
       });
@@ -368,9 +381,11 @@ describe('GET /api/v1/issues', () => {
       expect(response.body).toEqual({
         meta: {
           total: 5,
+          first: '/api/v1/issues?perPage=1&page=1',
           prev: '/api/v1/issues?perPage=1&page=2',
           curr: '/api/v1/issues?perPage=1&page=3',
           next: '/api/v1/issues?perPage=1&page=4',
+          last: '/api/v1/issues?perPage=1&page=5',
         },
         resources: [
           {

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -4,12 +4,16 @@ const request = require('supertest');
 
 const app = require('../src/app');
 const Issue = require('../src/models');
-const decodeQueryStringWithinUrl = require('../src/utilities');
+const { decodeQueryStringWithinUrl } = require('../src/utilities');
 
 console.log('process.env.HOME =', process.env.HOME);
 console.log('process.env.LD_LIBRARY_PATH =', process.env.LD_LIBRARY_PATH);
 
 let mongoMemoryServer;
+
+// For debugging, set the timeout for each test case the specified amount of time.
+// const MILLISECONDS_IN_FIVE_MINUTES = 5 * 60 * 1000;
+// jest.setTimeout(MILLISECONDS_IN_FIVE_MINUTES);
 
 beforeAll(async () => {
   mongoMemoryServer = await mms.MongoMemoryServer.create();
@@ -90,7 +94,7 @@ describe('GET /api/v1/issues', () => {
       meta: {
         total: 0,
         prev: null,
-        curr: '/api/v1/issues?perPage=100&page=1',
+        curr: '/api/v1/issues',
         next: null,
       },
       resources: [],

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -86,6 +86,12 @@ describe('GET /api/v1/issues', () => {
     // Assert.
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
+      meta: {
+        total: 0,
+        prev: null,
+        curr: '/api/v1/issues?perPage=100&page=1',
+        next: null,
+      },
       resources: [],
     });
   });
@@ -112,6 +118,12 @@ describe('GET /api/v1/issues', () => {
     expect(response.status).toEqual(200);
 
     expect(response.body).toEqual({
+      meta: {
+        total: 2,
+        prev: null,
+        curr: '/api/v1/issues?perPage=100&page=1',
+        next: null,
+      },
       resources: [
         {
           __v: expect.anything(),

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -71,6 +71,9 @@ describe('POST /api/v1/issues', () => {
 
     // Assert.
     expect(response.status).toEqual(201);
+    expect(response.headers.location).toEqual(
+      `/api/v1/issues/${response.body._id}`
+    );
     expect(response.body).toEqual({
       __v: expect.anything(),
       _id: expect.anything(),

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -196,6 +196,84 @@ describe('GET /api/v1/issues', () => {
       });
     }
   );
+
+  test(
+    'if there are Issue resources and "sort" is present as a URL query parameter,' +
+      ' should return 200 and representations of the resources',
+    async () => {
+      // Arrange.
+      const issue1 = await Issue.create({
+        status: '2 = selected',
+        deadline: new Date('2024-08-31T09:58:50.783Z'),
+        description:
+          'supplement the «information bundle» about pagination' +
+          ' with URLs for "first" and "last"',
+      });
+
+      const issue2 = await Issue.create({
+        status: '3 = in progress',
+        deadline: new Date('2024-08-31T09:59:50.783Z'),
+        description:
+          'enable the handler for GET requests' +
+          ' to select only certain fields, to sort, and to paginate',
+      });
+
+      // Act. (Request a sorting in descending order.)
+      const response1 = await request(app).get('/api/v1/issues?sort=-status');
+
+      // Assert.
+      expect(response1.status).toEqual(200);
+
+      const expectedResources1 = [
+        {
+          __v: expect.anything(),
+          _id: issue2._id.toString(),
+          createdAt: expect.anything(),
+          status: '3 = in progress',
+          deadline: '2024-08-31T09:59:50.783Z',
+          description:
+            'enable the handler for GET requests' +
+            ' to select only certain fields, to sort, and to paginate',
+        },
+        {
+          __v: expect.anything(),
+          _id: issue1._id.toString(),
+          createdAt: expect.anything(),
+          status: '2 = selected',
+          deadline: '2024-08-31T09:58:50.783Z',
+          description:
+            'supplement the «information bundle» about pagination' +
+            ' with URLs for "first" and "last"',
+        },
+      ];
+      expect(response1.body).toEqual({
+        meta: {
+          total: 2,
+          prev: null,
+          curr: '/api/v1/issues?sort=-status&perPage=100&page=1',
+          next: null,
+        },
+        resources: expectedResources1,
+      });
+
+      // Act. (Request a sorting in ascending order.)
+      const response2 = await request(app).get('/api/v1/issues?sort=status');
+
+      // Assert.
+      expect(response2.status).toEqual(200);
+
+      const expectedResources2 = expectedResources1.reverse();
+      expect(response2.body).toEqual({
+        meta: {
+          total: 2,
+          prev: null,
+          curr: '/api/v1/issues?sort=status&perPage=100&page=1',
+          next: null,
+        },
+        resources: expectedResources2,
+      });
+    }
+  );
 });
 
 describe('GET /api/v1/issues/:id', () => {

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -11,8 +11,8 @@ console.log('process.env.LD_LIBRARY_PATH =', process.env.LD_LIBRARY_PATH);
 
 let mongoMemoryServer;
 
-// For debugging, set the timeout for each test case the specified amount of time.
-// const MILLISECONDS_IN_FIVE_MINUTES = 5 * 60 * 1000;
+// // For debugging, set the timeout for each test case to the specified amount of time.
+// // const MILLISECONDS_IN_FIVE_MINUTES = 5 * 60 * 1000;
 // jest.setTimeout(MILLISECONDS_IN_FIVE_MINUTES);
 
 beforeAll(async () => {

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -275,8 +275,7 @@ describe('GET /api/v1/issues', () => {
         status: '2 = selected',
         deadline: new Date('2024-08-31T09:58:50.783Z'),
         description:
-          'supplement the «information bundle» about pagination' +
-          ' with URLs for "first" and "last"',
+          'supplement the pagination-info bundle with URLs for "first" and "last"',
       });
 
       const issue2 = await Issue.create({
@@ -311,8 +310,7 @@ describe('GET /api/v1/issues', () => {
           status: '2 = selected',
           deadline: '2024-08-31T09:58:50.783Z',
           description:
-            'supplement the «information bundle» about pagination' +
-            ' with URLs for "first" and "last"',
+            'supplement the pagination-info bundle with URLs for "first" and "last"',
         },
       ];
       expect(response1.body).toEqual({
@@ -346,7 +344,7 @@ describe('GET /api/v1/issues', () => {
 
   test(
     'if there are multiple pages of Issue resources,' +
-      ' should return 200 and a correct «information bundle» about pagination',
+      ' should return 200 and a correct pagination-info bundle',
     async () => {
       // Arrange.
       const indices = Array.from({ length: 5 }, (value, idx) => idx);

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -274,6 +274,50 @@ describe('GET /api/v1/issues', () => {
       });
     }
   );
+
+  test(
+    'if there are multiple pages of Issue resources,' +
+      ' should return 200 and a correct «information bundle» about pagination',
+    async () => {
+      // Arrange.
+      const indices = Array.from({ length: 5 }, (value, idx) => idx);
+
+      for (const idx of indices) {
+        await Issue.create({
+          status: '1 = backlog',
+          deadline: new Date(`2024-09-0${idx + 1}T16:41:47.722Z`),
+          description: `carry out step ${idx + 1}`,
+        });
+      }
+
+      // Act.
+      const response = await request(app).get(
+        '/api/v1/issues?perPage=1&page=3'
+      );
+
+      // Assert.
+      expect(response.status).toEqual(200);
+
+      expect(response.body).toEqual({
+        meta: {
+          total: 5,
+          prev: '/api/v1/issues?perPage=1&page=2',
+          curr: '/api/v1/issues?perPage=1&page=3',
+          next: '/api/v1/issues?perPage=1&page=4',
+        },
+        resources: [
+          {
+            __v: expect.anything(),
+            _id: expect.anything(),
+            createdAt: expect.anything(),
+            status: '1 = backlog',
+            deadline: '2024-09-03T16:41:47.722Z',
+            description: 'carry out step 3',
+          },
+        ],
+      });
+    }
+  );
 });
 
 describe('GET /api/v1/issues/:id', () => {

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -148,6 +148,71 @@ describe('GET /api/v1/issues', () => {
   });
 
   test(
+    'if there are Issue resource' +
+      ' and the URL query parameters represent a request filtering for filtering,' +
+      ' should return 200, a correct total, and representation of the resources',
+    async () => {
+      // Arrange.
+      const issue1 = await Issue.create({
+        status: '1 = backlog',
+        deadline: new Date('2024-08-31T21:43:31.696Z'),
+        description: 'containerize the backend',
+        epic: 'backend',
+      });
+
+      const issue2 = await Issue.create({
+        status: '1 = backlog',
+        deadline: new Date('2024-08-31T22:43:31.696Z'),
+        description:
+          'build a client (hopefully, a CLI tool combined with "jq")',
+        epic: 'frontend',
+      });
+
+      const issue3 = await Issue.create({
+        status: '1 = backlog',
+        deadline: new Date('2024-08-31T23:43:31.696Z'),
+        description: 'convert the "epic" field to a "parentId" field',
+        epic: 'backend',
+      });
+
+      // Act.
+      const response = await request(app).get('/api/v1/issues?epic=backend');
+
+      // Assert.
+      expect(response.status).toEqual(200);
+
+      expect(response.body).toEqual({
+        meta: {
+          total: 2,
+          prev: null,
+          curr: '/api/v1/issues?epic=backend&perPage=100&page=1',
+          next: null,
+        },
+        resources: [
+          {
+            __v: expect.anything(),
+            _id: issue1._id.toString(),
+            createdAt: expect.anything(),
+            status: '1 = backlog',
+            deadline: '2024-08-31T21:43:31.696Z',
+            description: 'containerize the backend',
+            epic: 'backend',
+          },
+          {
+            __v: expect.anything(),
+            _id: issue3._id.toString(),
+            createdAt: expect.anything(),
+            status: '1 = backlog',
+            deadline: '2024-08-31T23:43:31.696Z',
+            description: 'convert the "epic" field to a "parentId" field',
+            epic: 'backend',
+          },
+        ],
+      });
+    }
+  );
+
+  test(
     'if there are Issue resources and "select" is present as a URL query parameter,' +
       ' should return 200 and representations of the resources',
     async () => {

--- a/__test__/utilities.test.js
+++ b/__test__/utilities.test.js
@@ -4,7 +4,18 @@ const {
 } = require('../src/utilities');
 
 describe('decodeQueryStringWithinUrl', () => {
-  test('should replace each "," with "%2C"', () => {
+  test('if no query parameters, should return the same URL', () => {
+    // Arrange.
+    const url = 'localhost:5000/api/v1/issues';
+
+    // Act.
+    const urlWithQueryStringDecoded = decodeQueryStringWithinUrl(url);
+
+    // Assert.
+    expect(urlWithQueryStringDecoded).toEqual('localhost:5000/api/v1/issues');
+  });
+
+  test('if query parameters, should replace each "," with "%2C"', () => {
     // Arrange.
     const url =
       'localhost:5000?parameter_1=value_1_1,value_2_1&parameter_2=value_2_1';

--- a/__test__/utilities.test.js
+++ b/__test__/utilities.test.js
@@ -1,0 +1,77 @@
+const { determinePaginationInfo } = require('../src/utilities');
+
+describe('determinePaginationInfo', () => {
+  // TODO: (2024/09/01, 11:16)
+  //      refine the implementation for the case `total === 0` + update this test accordingly
+  test('if "total" is 0, should ...', () => {
+    // Arrage.
+    const reqQueryPerPage = '10';
+    const reqQueryPage = '1';
+    const total = 0;
+
+    // Act.
+    const paginationInfo = determinePaginationInfo(
+      reqQueryPerPage,
+      reqQueryPage,
+      total
+    );
+
+    // Assert.
+    expect(paginationInfo).toEqual({
+      perPage: 10,
+      pageFirst: 1,
+      pagePrev: -1,
+      pageCurr: 0,
+      pageNext: null,
+      pageLast: 0,
+    });
+  });
+
+  test('the happy path when "reqQueryPage" equals a number', () => {
+    // Arrange.
+    const reqQueryPerPage = '10';
+    const reqQueryPage = '5';
+    const total = 103;
+
+    // Act.
+    const paginationInfo = determinePaginationInfo(
+      reqQueryPerPage,
+      reqQueryPage,
+      total
+    );
+
+    // Assert.
+    expect(paginationInfo).toEqual({
+      perPage: 10,
+      pageFirst: 1,
+      pagePrev: 4,
+      pageCurr: 5,
+      pageNext: 6,
+      pageLast: 11,
+    });
+  });
+
+  test('the happy path when "reqQueryPage" equals `undefined`', () => {
+    // Arrange.
+    const reqQueryPerPage = '10';
+    const reqQueryPage = undefined;
+    const total = 103;
+
+    // Act.
+    const paginationInfo = determinePaginationInfo(
+      reqQueryPerPage,
+      reqQueryPage,
+      total
+    );
+
+    // Assert.
+    expect(paginationInfo).toEqual({
+      perPage: 10,
+      pageFirst: 1,
+      pagePrev: null,
+      pageCurr: 1,
+      pageNext: 2,
+      pageLast: 11,
+    });
+  });
+});

--- a/__test__/utilities.test.js
+++ b/__test__/utilities.test.js
@@ -31,30 +31,22 @@ describe('decodeQueryStringWithinUrl', () => {
 });
 
 describe('determinePaginationInfo', () => {
-  // TODO: (2024/09/01, 11:16)
-  //      refine the implementation for the case `total === 0` + update this test accordingly
-  test('if "total" is 0, should ...', () => {
+  test('if "total" is 0, should throw an error', () => {
     // Arrage.
     const reqQueryPerPage = '10';
     const reqQueryPage = '1';
     const total = 0;
 
-    // Act.
-    const paginationInfo = determinePaginationInfo(
-      reqQueryPerPage,
-      reqQueryPage,
-      total
+    const funcThatWillThrowError = () => {
+      return determinePaginationInfo(reqQueryPerPage, reqQueryPage, total);
+    };
+
+    // Act. + Assert.
+    const expectedError = new Error(
+      '"total" must be a strictly positive integer'
     );
 
-    // Assert.
-    expect(paginationInfo).toEqual({
-      perPage: 10,
-      pageFirst: 1,
-      pagePrev: -1,
-      pageCurr: 0,
-      pageNext: null,
-      pageLast: 0,
-    });
+    expect(funcThatWillThrowError).toThrowError(expectedError);
   });
 
   test('the happy path when "reqQueryPage" equals a number', () => {

--- a/__test__/utilities.test.js
+++ b/__test__/utilities.test.js
@@ -1,4 +1,23 @@
-const { determinePaginationInfo } = require('../src/utilities');
+const {
+  decodeQueryStringWithinUrl,
+  determinePaginationInfo,
+} = require('../src/utilities');
+
+describe('decodeQueryStringWithinUrl', () => {
+  test('should replace each "," with "%2C"', () => {
+    // Arrange.
+    const url =
+      'localhost:5000?parameter_1=value_1_1,value_2_1&parameter_2=value_2_1';
+
+    // Act.
+    const urlWithQueryStringDecoded = decodeQueryStringWithinUrl(url);
+
+    // Assert.
+    expect(urlWithQueryStringDecoded).toEqual(
+      'localhost:5000?parameter_1=value_1_1%2Cvalue_2_1&parameter_2=value_2_1'
+    );
+  });
+});
 
 describe('determinePaginationInfo', () => {
   // TODO: (2024/09/01, 11:16)

--- a/__test__/utilities.test.js
+++ b/__test__/utilities.test.js
@@ -1,6 +1,6 @@
 const {
   decodeQueryStringWithinUrl,
-  determinePaginationInfo,
+  determinePaginationInfoInitial,
 } = require('../src/utilities');
 
 describe('decodeQueryStringWithinUrl', () => {
@@ -30,7 +30,7 @@ describe('decodeQueryStringWithinUrl', () => {
   });
 });
 
-describe('determinePaginationInfo', () => {
+describe('determinePaginationInfoInitial', () => {
   test('if "total" is 0, should throw an error', () => {
     // Arrage.
     const reqQueryPerPage = '10';
@@ -38,7 +38,11 @@ describe('determinePaginationInfo', () => {
     const total = 0;
 
     const funcThatWillThrowError = () => {
-      return determinePaginationInfo(reqQueryPerPage, reqQueryPage, total);
+      return determinePaginationInfoInitial(
+        reqQueryPerPage,
+        reqQueryPage,
+        total
+      );
     };
 
     // Act. + Assert.
@@ -56,14 +60,14 @@ describe('determinePaginationInfo', () => {
     const total = 103;
 
     // Act.
-    const paginationInfo = determinePaginationInfo(
+    const paginationInfoInitial = determinePaginationInfoInitial(
       reqQueryPerPage,
       reqQueryPage,
       total
     );
 
     // Assert.
-    expect(paginationInfo).toEqual({
+    expect(paginationInfoInitial).toEqual({
       perPage: 10,
       pageFirst: 1,
       pagePrev: 4,
@@ -80,14 +84,14 @@ describe('determinePaginationInfo', () => {
     const total = 103;
 
     // Act.
-    const paginationInfo = determinePaginationInfo(
+    const paginationInfoInitial = determinePaginationInfoInitial(
       reqQueryPerPage,
       reqQueryPage,
       total
     );
 
     // Assert.
-    expect(paginationInfo).toEqual({
+    expect(paginationInfoInitial).toEqual({
       perPage: 10,
       pageFirst: 1,
       pagePrev: null,

--- a/src/app.js
+++ b/src/app.js
@@ -67,27 +67,14 @@ app.get('/api/v1/issues', async (req, res) => {
   // Apply filtering criteria.
   query = Issue.find(queryJSON);
 
-  // Make the query return only the fields
-  // specified by the value of the `select` query parameter.
-  if (req.query.select) {
-    const fields = req.query.select.split(',');
-    query = query.select(fields);
-  }
-
-  // Apply sorting.
-  if (req.query.sort) {
-    const sortBy = req.query.sort.split(',').join(' ');
-    query = query.sort(sortBy);
-  }
-
   // Initialize an «information bundle»
   // which, in a step-by-step fashion, will be supplemented with information
   // about how to paginate beyond the returned resources.
   // (The final version of that bundle will be sent in the body of the HTTP response.)
   const meta = {};
 
-  // Supplement the information bundle with the number of all resources,
-  // which match the filtering criteria.
+  //  - Supplement the information bundle with the number of all resources,
+  //    which match the filtering criteria.
   try {
     const queryClone = query.clone();
     const total = await queryClone.countDocuments();
@@ -116,8 +103,8 @@ app.get('/api/v1/issues', async (req, res) => {
     return;
   }
 
-  // Supplement the information bundle with the indices of
-  // the first, previous, current, next, and last pages.
+  //  - Supplement the information bundle with the indices of
+  //    the first, previous, current, next, and last pages.
   const { perPage, pageFirst, pagePrev, pageCurr, pageNext, pageLast } =
     determinePaginationInfo(req.query.perPage, req.query.page, meta.total);
 
@@ -141,6 +128,19 @@ app.get('/api/v1/issues', async (req, res) => {
     meta.prev = `/api/v1/issues` + `?` + queryParams.toString();
   } else {
     meta.prev = null;
+  }
+
+  // Make the query return only the fields
+  // specified by the value of the `select` query parameter.
+  if (req.query.select) {
+    const fields = req.query.select.split(',');
+    query = query.select(fields);
+  }
+
+  // Apply sorting.
+  if (req.query.sort) {
+    const sortBy = req.query.sort.split(',').join(' ');
+    query = query.sort(sortBy);
   }
 
   // Apply pagination.

--- a/src/app.js
+++ b/src/app.js
@@ -33,7 +33,7 @@ app.post('/api/v1/issues', async (req, res) => {
 
 app.get('/api/v1/issues', async (req, res) => {
   try {
-    const issues = await Issue.find();
+    const issues = await Issue.find(req.query);
 
     res.status(200).json({
       resources: issues,

--- a/src/app.js
+++ b/src/app.js
@@ -41,7 +41,7 @@ app.get('/api/v1/issues', async (req, res) => {
     ...req.query,
   };
 
-  const fieldsToExcludeFromReqQuery = ['select', 'sort'];
+  const fieldsToExcludeFromReqQuery = ['select', 'sort', 'perPage', 'page'];
   for (f of fieldsToExcludeFromReqQuery) {
     delete reqQuery[f];
   }
@@ -73,6 +73,18 @@ app.get('/api/v1/issues', async (req, res) => {
     const sortBy = req.query.sort.split(',').join(' ');
     query = query.sort(sortBy);
   }
+
+  // Apply pagination.
+  // console.log('req.query.perPage', req.query.perPage);
+  let perPage = parseInt(req.query.perPage) || 100;
+  // console.log('perPage', perPage);
+  perPage = Math.min(perPage, 100);
+  const page = parseInt(req.query.page) || 1;
+  // console.log('perPage', perPage);
+  // console.log('page', page);
+  const countDocumentsToSkip = (page - 1) * perPage;
+  // console.log('countDocumentsToSkip', countDocumentsToSkip);
+  query = query.skip(countDocumentsToSkip).limit(perPage);
 
   try {
     const issues = await query;

--- a/src/app.js
+++ b/src/app.js
@@ -41,7 +41,7 @@ app.get('/api/v1/issues', async (req, res) => {
     ...req.query,
   };
 
-  const fieldsToExcludeFromReqQuery = ['select'];
+  const fieldsToExcludeFromReqQuery = ['select', 'sort'];
   for (f of fieldsToExcludeFromReqQuery) {
     delete reqQuery[f];
   }
@@ -66,6 +66,12 @@ app.get('/api/v1/issues', async (req, res) => {
   if (req.query.select) {
     const fields = req.query.select.split(',');
     query = query.select(fields);
+  }
+
+  // Apply sorting.
+  if (req.query.sort) {
+    const sortBy = req.query.sort.split(',').join(' ');
+    query = query.sort(sortBy);
   }
 
   try {

--- a/src/app.js
+++ b/src/app.js
@@ -29,7 +29,10 @@ app.post('/api/v1/issues', async (req, res) => {
     return;
   }
 
-  res.status(201).json(newIssue);
+  res
+    .status(201)
+    .set('Location', `/api/v1/issues/${newIssue._id.toString()}`)
+    .json(newIssue);
 });
 
 app.get('/api/v1/issues', async (req, res) => {

--- a/src/app.js
+++ b/src/app.js
@@ -54,9 +54,7 @@ app.get('/api/v1/issues', async (req, res) => {
 
     delete reqQuery[f];
   }
-  console.log('reqQuery', reqQuery);
   const queryRawStr = JSON.stringify(reqQuery);
-  console.log('queryRawStr', queryRawStr);
 
   // Create the following Mongoose operators: `$in`, `$lt`, `$lte`, `$gt`, `$gte` .
   const queryStr = queryRawStr.replace(

--- a/src/app.js
+++ b/src/app.js
@@ -32,8 +32,24 @@ app.post('/api/v1/issues', async (req, res) => {
 });
 
 app.get('/api/v1/issues', async (req, res) => {
+  let query;
+
+  const queryRawStr = JSON.stringify(req.query);
+  console.log('queryRawStr', queryRawStr);
+
+  // Create the following Mongoose operators: `$in`, `$lt`, `$lte`, `$gt`, `$gte` .
+  const queryStr = queryRawStr.replace(
+    /\b(in|lt|lte|gt|gte)\b/g,
+    (match) => `$${match}`
+  );
+  console.log('queryStr', queryStr);
+  const queryJSON = JSON.parse(queryStr);
+  console.log('queryJSON', queryJSON);
+
+  query = Issue.find(queryJSON);
+
   try {
-    const issues = await Issue.find(req.query);
+    const issues = await query;
 
     res.status(200).json({
       resources: issues,

--- a/src/app.js
+++ b/src/app.js
@@ -64,7 +64,7 @@ app.get('/api/v1/issues', async (req, res) => {
   const queryJSON = JSON.parse(queryStr);
   console.log('queryJSON', queryJSON);
 
-  // Initialize the query.
+  // Apply filtering criteria.
   query = Issue.find(queryJSON);
 
   // Make the query return only the fields
@@ -80,11 +80,14 @@ app.get('/api/v1/issues', async (req, res) => {
     query = query.sort(sortBy);
   }
 
-  // Put together an «information bundle»,
-  // which indicates how to paginate beyond the returned `issues`.
-  // (That information bundle will be sent in the body of the HTTP response.)
+  // Initialize an «information bundle»
+  // which, in a step-by-step fashion, will be supplemented with information
+  // about how to paginate beyond the returned resources.
+  // (The final version of that bundle will be sent in the body of the HTTP response.)
   const meta = {};
 
+  // Supplement the information bundle with the number of all resources,
+  // which match the filtering criteria.
   try {
     const queryClone = query.clone();
     const total = await queryClone.countDocuments();
@@ -113,6 +116,8 @@ app.get('/api/v1/issues', async (req, res) => {
     return;
   }
 
+  // Supplement the information bundle with the indices of
+  // the first, previous, current, next, and last pages.
   const { perPage, pageFirst, pagePrev, pageCurr, pageNext, pageLast } =
     determinePaginationInfo(req.query.perPage, req.query.page, meta.total);
 

--- a/src/app.js
+++ b/src/app.js
@@ -71,7 +71,7 @@ app.get('/api/v1/issues', async (req, res) => {
   // which, in a step-by-step fashion, will be supplemented with information
   // about how to paginate beyond the returned resources.
   // (The completed bundle will be sent in the body of the HTTP response.)
-  const paginationInfoFinal = {};
+  let paginationInfoFinal = {};
 
   //  - Supplement the pagination-info bundle with the number of all resources,
   //    which match the filtering criteria.
@@ -90,13 +90,17 @@ app.get('/api/v1/issues', async (req, res) => {
   }
 
   if (paginationInfoFinal.total === 0) {
+    paginationInfoFinal = {
+      total: 0,
+      first: '/api/v1/issues?page=1',
+      prev: null,
+      curr: '/api/v1/issues',
+      next: null,
+      last: '/api/v1/issues?page=1',
+    };
+
     res.status(200).json({
-      meta: {
-        total: 0,
-        prev: null,
-        curr: '/api/v1/issues',
-        next: null,
-      },
+      meta: paginationInfoFinal,
       resources: [],
     });
 
@@ -117,6 +121,17 @@ app.get('/api/v1/issues', async (req, res) => {
     ...excludedParam2Value,
   });
   queryParams.set('perPage', perPage);
+
+  queryParams.set('page', pageFirst);
+  paginationInfoFinal.first = `/api/v1/issues` + `?` + queryParams.toString();
+
+  if (pagePrev) {
+    queryParams.set('page', pagePrev);
+    paginationInfoFinal.prev = `/api/v1/issues` + `?` + queryParams.toString();
+  } else {
+    paginationInfoFinal.prev = null;
+  }
+
   queryParams.set('page', pageCurr);
   paginationInfoFinal.curr = `/api/v1/issues` + `?` + queryParams.toString();
 
@@ -127,16 +142,8 @@ app.get('/api/v1/issues', async (req, res) => {
     paginationInfoFinal.next = null;
   }
 
-  if (pagePrev) {
-    queryParams.set('page', pagePrev);
-    paginationInfoFinal.prev = `/api/v1/issues` + `?` + queryParams.toString();
-  } else {
-    paginationInfoFinal.prev = null;
-  }
-
-  // TODO: (2024/09/01, 16:09)
-  //      supplement the pagination-info bundle
-  //      with URLs for "first" and "last"
+  queryParams.set('page', pageLast);
+  paginationInfoFinal.last = `/api/v1/issues` + `?` + queryParams.toString();
 
   // Make the query return only the fields
   // specified by the value of the `select` query parameter.

--- a/src/app.js
+++ b/src/app.js
@@ -91,19 +91,19 @@ app.get('/api/v1/issues', async (req, res) => {
   const startIndex = (page - 1) * perPage;
   const finalIndex = page * perPage;
   // console.log('startIndex', startIndex);
-  query = query.skip(startIndex).limit(perPage);
 
   try {
-    const issues = await query;
-
     // Put together an «information bundle»,
     // which indicates how to paginate beyond the returned `issues`.
     // (That information bundle,
     // which will be sent in the body of the HTTP response.)
     const meta = {};
 
-    const total = await Issue.countDocuments();
+    const total = await query.clone().countDocuments();
     meta.total = total;
+
+    query = query.skip(startIndex).limit(perPage);
+    const issues = await query;
 
     const queryParams = new URLSearchParams({
       ...reqQuery,

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -18,6 +18,10 @@ exports.decodeQueryStringWithinUrl = (url) => {
 const MAX_PER_PAGE = 100;
 
 exports.determinePaginationInfo = (reqQueryPerPage, reqQueryPage, total) => {
+  if (typeof total !== 'number' || total <= 0) {
+    throw Error('"total" must be a strictly positive integer');
+  }
+
   // console.log('reqQueryPerPage', reqQueryPerPage);
   let perPage = parseInt(reqQueryPerPage) || MAX_PER_PAGE;
   perPage = Math.min(perPage, MAX_PER_PAGE);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -26,13 +26,11 @@ exports.determinePaginationInfoInitial = (
     throw Error('"total" must be a strictly positive integer');
   }
 
-  // console.log('reqQueryPerPage', reqQueryPerPage);
   let perPage = parseInt(reqQueryPerPage) || MAX_PER_PAGE;
   perPage = Math.min(perPage, MAX_PER_PAGE);
 
   const pageLast = Math.ceil(total / perPage);
 
-  // console.log('reqQueryPage', reqQueryPage);
   let page = parseInt(reqQueryPage) || 1;
   page = page < 1 ? 1 : page;
   page = page > pageLast ? pageLast : page;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -17,7 +17,11 @@ exports.decodeQueryStringWithinUrl = (url) => {
 
 const MAX_PER_PAGE = 100;
 
-exports.determinePaginationInfo = (reqQueryPerPage, reqQueryPage, total) => {
+exports.determinePaginationInfoInitial = (
+  reqQueryPerPage,
+  reqQueryPage,
+  total
+) => {
   if (typeof total !== 'number' || total <= 0) {
     throw Error('"total" must be a strictly positive integer');
   }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -21,8 +21,6 @@ exports.decodeQueryStringWithinUrl = (url) => {
 
 const MAX_PER_PAGE = 100;
 
-// TODO: (2024/09/01, 10:19)
-//      write a test for the case when `total === 0`
 exports.determinePaginationInfo = (reqQueryPerPage, reqQueryPage, total) => {
   // console.log('reqQueryPerPage', reqQueryPerPage);
   let perPage = parseInt(reqQueryPerPage) || MAX_PER_PAGE;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -2,7 +2,7 @@
 //      create a separate file,
 //      which tests this function on its own
 //                  (= implements automated tests for this function in isolation)
-const decodeQueryStringWithinUrl = (url) => {
+exports.decodeQueryStringWithinUrl = (url) => {
   const [baseUrl, queryStringRaw] = url.split('?');
 
   if (!queryStringRaw) {
@@ -19,4 +19,31 @@ const decodeQueryStringWithinUrl = (url) => {
   return `${baseUrl}?${queryStringDecoded}`;
 };
 
-module.exports = decodeQueryStringWithinUrl;
+const MAX_PER_PAGE = 100;
+
+// TODO: (2024/09/01, 10:19)
+//      write a test for the case when `total === 0`
+exports.determinePaginationInfo = (reqQueryPerPage, reqQueryPage, total) => {
+  // console.log('reqQueryPerPage', reqQueryPerPage);
+  let perPage = parseInt(reqQueryPerPage) || MAX_PER_PAGE;
+  perPage = Math.min(perPage, MAX_PER_PAGE);
+
+  const pageLast = Math.ceil(total / perPage);
+
+  // console.log('reqQueryPage', reqQueryPage);
+  let page = parseInt(reqQueryPage) || 1;
+  page = page < 1 ? 1 : page;
+  page = page > pageLast ? pageLast : page;
+
+  const pagePrev = page == 1 ? null : page - 1;
+  const pageNext = page == pageLast ? null : page + 1;
+
+  return {
+    perPage,
+    pageFirst: 1,
+    pagePrev,
+    pageCurr: page,
+    pageNext,
+    pageLast,
+  };
+};

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,0 +1,22 @@
+// TODO: (2024/08/31, 11:26)
+//      create a separate file,
+//      which tests this function on its own
+//                  (= implements automated tests for this function in isolation)
+const decodeQueryStringWithinUrl = (url) => {
+  const [baseUrl, queryStringRaw] = url.split('?');
+
+  if (!queryStringRaw) {
+    return baseUrl;
+  }
+
+  const paramsRaw = new URLSearchParams(queryStringRaw);
+  const paramsDecoded = new URLSearchParams();
+  paramsRaw.forEach((value, key) => {
+    paramsDecoded.set(key, decodeURIComponent(value));
+  });
+  const queryStringDecoded = paramsDecoded.toString();
+
+  return `${baseUrl}?${queryStringDecoded}`;
+};
+
+module.exports = decodeQueryStringWithinUrl;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,7 +1,3 @@
-// TODO: (2024/08/31, 11:26)
-//      create a separate file,
-//      which tests this function on its own
-//                  (= implements automated tests for this function in isolation)
 exports.decodeQueryStringWithinUrl = (url) => {
   const [baseUrl, queryStringRaw] = url.split('?');
 


### PR DESCRIPTION
this pull request:

- enables the `GET /api/v1/issues` handler to
  - always perform pagination, consistent with optional filtering
  - optionally select only specific fields from the query hits/results
  - optionally sort the query hits/results

- re-arranges the groups of automated tests within `__test__/app.test.js`
  to match the order in `README.md` and in `src/app.js`

- makes the `POST /api/v1/issues` handler set a `Location` header in its HTTP response
  (for the case of its happy-case execution path)