### PR TITLE
Modify the `Issue` model by converting its `epic` field to a `parentId` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,6 @@ in it, issue the following requests to the HTTP server:
 
 
 
-<u>TODO: (2024/09/02, 05:44) update the example requests below (by creating "parentIds" and "issues" associated with those "parentIds")</u>
-
 create one
 
 ```bash
@@ -237,12 +235,12 @@ curl -v \
 
 # ...
 < HTTP/1.1 201 Created
-< Location: /api/v1/issues/66d53901268394815f77a7eb
+< Location: /api/v1/issues/66dc11fd1c3a2a743744172f
 # ...
 {
    "__v" : 0,
-   "_id" : "66d53901268394815f77a7eb",
-   "createdAt" : "2024-09-02T04:03:13.830Z",
+   "_id" : "66dc11fd1c3a2a743744172f",
+   "createdAt" : "2024-09-07T08:42:37.374Z",
    "deadline" : "2024-09-08T21:08:36.367Z",
    "description" : "backend",
    "parentId" : null,
@@ -416,9 +414,9 @@ curl -v \
 # ...
 {
    "meta" : {
-      "curr" : "/api/v1/issues?parentId=66d53ab6cfe29c33e5c216cf&perPage=100&page=1",
-      "first" : "/api/v1/issues?parentId=66d53ab6cfe29c33e5c216cf&perPage=100&page=1",
-      "last" : "/api/v1/issues?parentId=66d53ab6cfe29c33e5c216cf&perPage=100&page=1",
+      "curr" : "/api/v1/issues?parentId=66dc122e1c3a2a7437441731&perPage=100&page=1",
+      "first" : "/api/v1/issues?parentId=66dc122e1c3a2a7437441731&perPage=100&page=1",
+      "last" : "/api/v1/issues?parentId=66dc122e1c3a2a7437441731&perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 1
@@ -426,15 +424,64 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d53bb2cfe29c33e5c216d5",
-         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "_id" : "66dc125d1c3a2a7437441737",
+         "createdAt" : "2024-09-07T08:44:13.781Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "parentId" : "66dc122e1c3a2a7437441731",
          "status" : "1 = backlog"
       }
    ]
 }
+
+
+
+curl -v \
+   localhost:5000/api/v1/issues?parentId=null \
+   | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "meta" : {
+      "curr" : "/api/v1/issues?parentId=null&perPage=100&page=1",
+      "first" : "/api/v1/issues?parentId=null&perPage=100&page=1",
+      "last" : "/api/v1/issues?parentId=null&perPage=100&page=1",
+      "next" : null,
+      "prev" : null,
+      "total" : 2
+   },
+   "resources" : [
+      {
+         "__v" : 0,
+         "_id" : "66dc11fd1c3a2a743744172f",
+         "createdAt" : "2024-09-07T08:42:37.374Z",
+         "deadline" : "2024-09-08T21:08:36.367Z",
+         "description" : "backend",
+         "parentId" : null,
+         "status" : "3 = in progress"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66dc122e1c3a2a7437441731",
+         "createdAt" : "2024-09-07T08:43:26.920Z",
+         "deadline" : "2024-09-15T21:08:36.367Z",
+         "description" : "frontend",
+         "parentId" : null,
+         "status" : "1 = backlog"
+      }
+   ]
+}
+
+
+
+curl -v \
+   localhost:5000/api/v1/issues?parentId= \
+   | json_pp
+
+# The HTTP response to this request is the same as
+# the response to the preceding request. 
 ```
 
 <u>TODO: (2024/08/29; 11:04)</u> consider whether this application needs to support Mongoose operators via URL query strings
@@ -459,8 +506,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d53ab6cfe29c33e5c216cf",
-         "createdAt" : "2024-09-02T04:10:30.515Z",
+         "_id" : "66dc122e1c3a2a7437441731",
+         "createdAt" : "2024-09-07T08:43:26.920Z",
          "deadline" : "2024-09-15T21:08:36.367Z",
          "description" : "frontend",
          "parentId" : null,
@@ -468,20 +515,20 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d53bb2cfe29c33e5c216d5",
-         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "_id" : "66dc125d1c3a2a7437441737",
+         "createdAt" : "2024-09-07T08:44:13.781Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "parentId" : "66dc122e1c3a2a7437441731",
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66d53bd1cfe29c33e5c216d8",
-         "createdAt" : "2024-09-02T04:15:13.791Z",
+         "_id" : "66dc12711c3a2a743744173a",
+         "createdAt" : "2024-09-07T08:44:33.757Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "parentId" : "66d53901268394815f77a7eb",
+         "parentId" : "66dc11fd1c3a2a743744172f",
          "status" : "2 = selected"
       }
    ]
@@ -507,27 +554,27 @@ curl -v \
    },
    "resources" : [
       {
-         "_id" : "66d53901268394815f77a7eb",
+         "_id" : "66dc11fd1c3a2a743744172f",
          "description" : "backend",
          "status" : "3 = in progress"
       },
       {
-         "_id" : "66d53ab6cfe29c33e5c216cf",
+         "_id" : "66dc122e1c3a2a7437441731",
          "description" : "frontend",
          "status" : "1 = backlog"
       },
       {
-         "_id" : "66d53b08cfe29c33e5c216d2",
+         "_id" : "66dc12441c3a2a7437441734",
          "description" : "convert the `epic` field to a `parentId` field",
          "status" : "3 = in progress"
       },
       {
-         "_id" : "66d53bb2cfe29c33e5c216d5",
+         "_id" : "66dc125d1c3a2a7437441737",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "status" : "1 = backlog"
       },
       {
-         "_id" : "66d53bd1cfe29c33e5c216d8",
+         "_id" : "66dc12711c3a2a743744173a",
          "description" : "containerize the backend",
          "status" : "2 = selected"
       }
@@ -555,8 +602,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d53901268394815f77a7eb",
-         "createdAt" : "2024-09-02T04:03:13.830Z",
+         "_id" : "66dc11fd1c3a2a743744172f",
+         "createdAt" : "2024-09-07T08:42:37.374Z",
          "deadline" : "2024-09-08T21:08:36.367Z",
          "description" : "backend",
          "parentId" : null,
@@ -564,26 +611,26 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d53b08cfe29c33e5c216d2",
-         "createdAt" : "2024-09-02T04:11:52.108Z",
+         "_id" : "66dc12441c3a2a7437441734",
+         "createdAt" : "2024-09-07T08:43:48.263Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
-         "parentId" : "66d53901268394815f77a7eb",
+         "parentId" : "66dc11fd1c3a2a743744172f",
          "status" : "3 = in progress"
       },
       {
          "__v" : 0,
-         "_id" : "66d53bd1cfe29c33e5c216d8",
-         "createdAt" : "2024-09-02T04:15:13.791Z",
+         "_id" : "66dc12711c3a2a743744173a",
+         "createdAt" : "2024-09-07T08:44:33.757Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "parentId" : "66d53901268394815f77a7eb",
+         "parentId" : "66dc11fd1c3a2a743744172f",
          "status" : "2 = selected"
       },
       {
          "__v" : 0,
-         "_id" : "66d53ab6cfe29c33e5c216cf",
-         "createdAt" : "2024-09-02T04:10:30.515Z",
+         "_id" : "66dc122e1c3a2a7437441731",
+         "createdAt" : "2024-09-07T08:43:26.920Z",
          "deadline" : "2024-09-15T21:08:36.367Z",
          "description" : "frontend",
          "parentId" : null,
@@ -591,11 +638,11 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d53bb2cfe29c33e5c216d5",
-         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "_id" : "66dc125d1c3a2a7437441737",
+         "createdAt" : "2024-09-07T08:44:13.781Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "parentId" : "66dc122e1c3a2a7437441731",
          "status" : "1 = backlog"
       }
    ]
@@ -622,8 +669,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d53ab6cfe29c33e5c216cf",
-         "createdAt" : "2024-09-02T04:10:30.515Z",
+         "_id" : "66dc122e1c3a2a7437441731",
+         "createdAt" : "2024-09-07T08:43:26.920Z",
          "deadline" : "2024-09-15T21:08:36.367Z",
          "description" : "frontend",
          "parentId" : null,
@@ -631,26 +678,26 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d53bb2cfe29c33e5c216d5",
-         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "_id" : "66dc125d1c3a2a7437441737",
+         "createdAt" : "2024-09-07T08:44:13.781Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "parentId" : "66dc122e1c3a2a7437441731",
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66d53bd1cfe29c33e5c216d8",
-         "createdAt" : "2024-09-02T04:15:13.791Z",
+         "_id" : "66dc12711c3a2a743744173a",
+         "createdAt" : "2024-09-07T08:44:33.757Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "parentId" : "66d53901268394815f77a7eb",
+         "parentId" : "66dc11fd1c3a2a743744172f",
          "status" : "2 = selected"
       },
       {
          "__v" : 0,
-         "_id" : "66d53901268394815f77a7eb",
-         "createdAt" : "2024-09-02T04:03:13.830Z",
+         "_id" : "66dc11fd1c3a2a743744172f",
+         "createdAt" : "2024-09-07T08:42:37.374Z",
          "deadline" : "2024-09-08T21:08:36.367Z",
          "description" : "backend",
          "parentId" : null,
@@ -658,11 +705,11 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d53b08cfe29c33e5c216d2",
-         "createdAt" : "2024-09-02T04:11:52.108Z",
+         "_id" : "66dc12441c3a2a7437441734",
+         "createdAt" : "2024-09-07T08:43:48.263Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
-         "parentId" : "66d53901268394815f77a7eb",
+         "parentId" : "66dc11fd1c3a2a743744172f",
          "status" : "3 = in progress"
       }
    ]
@@ -689,20 +736,20 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d53b08cfe29c33e5c216d2",
-         "createdAt" : "2024-09-02T04:11:52.108Z",
+         "_id" : "66dc12441c3a2a7437441734",
+         "createdAt" : "2024-09-07T08:43:48.263Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
-         "parentId" : "66d53901268394815f77a7eb",
+         "parentId" : "66dc11fd1c3a2a743744172f",
          "status" : "3 = in progress"
       },
       {
          "__v" : 0,
-         "_id" : "66d53bb2cfe29c33e5c216d5",
-         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "_id" : "66dc125d1c3a2a7437441737",
+         "createdAt" : "2024-09-07T08:44:13.781Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "parentId" : "66dc122e1c3a2a7437441731",
          "status" : "1 = backlog"
       }
    ]
@@ -749,11 +796,11 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d53bd1cfe29c33e5c216d8",
-   "createdAt" : "2024-09-02T04:15:13.791Z",
+   "_id" : "66dc12711c3a2a743744173a",
+   "createdAt" : "2024-09-07T08:44:33.757Z",
    "deadline" : "2024-08-31T23:08:36.367Z",
    "description" : "containerize the backend",
-   "parentId" : "66d53901268394815f77a7eb",
+   "parentId" : "66dc11fd1c3a2a743744172f",
    "status" : "2 = selected"
 }
 ```
@@ -805,11 +852,11 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d53bd1cfe29c33e5c216d8",
-   "createdAt" : "2024-09-02T04:15:13.791Z",
+   "_id" : "66dc12711c3a2a743744173a",
+   "createdAt" : "2024-09-07T08:44:33.757Z",
    "deadline" : "2024-08-31T23:08:36.367Z",
    "description" : "containerize the backend",
-   "parentId" : "66d53901268394815f77a7eb",
+   "parentId" : "66dc11fd1c3a2a743744172f",
    "status" : "3 = in progress"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ in it, issue the following requests to the HTTP server:
 
 
 
+<u>TODO: (2024/09/02, 05:44) update the example requests below (by creating "epics" and "issues" associated with those "epics")</u>
+
 create one
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ in it, issue the following requests to the HTTP server:
 
 
 
-<u>TODO: (2024/09/02, 05:44) update the example requests below (by creating "epics" and "issues" associated with those "epics")</u>
+<u>TODO: (2024/09/02, 05:44) update the example requests below (by creating "parentIds" and "issues" associated with those "parentIds")</u>
 
 create one
 
@@ -229,8 +229,62 @@ curl -v \
    -H "Content-Type: application/json" \
    -d "{
       \"status\": \"3 = in progress\",
+      \"deadline\": \"2024-09-08T21:08:36.367Z\",
+      \"description\": \"backend\"
+   }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
+
+# ...
+< HTTP/1.1 201 Created
+< Location: /api/v1/issues/66d53901268394815f77a7eb
+# ...
+{
+   "__v" : 0,
+   "_id" : "66d53901268394815f77a7eb",
+   "createdAt" : "2024-09-02T04:03:13.830Z",
+   "deadline" : "2024-09-08T21:08:36.367Z",
+   "description" : "backend",
+   "parentId" : null,
+   "status" : "3 = in progress"
+}
+
+
+
+export ISSUE_BACKEND_ID=<the-_id-present-in-the-preceding-HTTP-response>
+
+export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_BACKEND_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
+
+
+
+curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"1 = backlog\",
+      \"deadline\": \"2024-09-15T21:08:36.367Z\",
+      \"description\": \"frontend\"
+   }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
+
+# ...
+< HTTP/1.1 201 Created
+# ...
+
+
+
+export ISSUE_FRONTEND_ID=<the-_id-present-in-the-preceding-HTTP-response>
+
+
+
+curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"3 = in progress\",
       \"deadline\": \"2024-08-31T21:08:36.367Z\",
-      \"epic\": \"backend\",
+      \"parentId\": \"${ISSUE_BACKEND_ID}\",
       \"description\": \"convert the \`epic\` field to a \`parentId\` field\"
    }" \
    localhost:5000/api/v1/issues \
@@ -238,17 +292,7 @@ curl -v \
 
 # ...
 < HTTP/1.1 201 Created
-< Location: /api/v1/issues/66d4bc0775ddfdd6c15a594f
 # ...
-{
-   "__v" : 0,
-   "_id" : "66d4bc0775ddfdd6c15a594f",
-   "createdAt" : "2024-09-01T19:09:59.779Z",
-   "deadline" : "2024-08-31T21:08:36.367Z",
-   "description" : "convert the `epic` field to a `parentId` field",
-   "epic" : "backend",
-   "status" : "3 = in progress"
-}
 ```
 
 ```bash
@@ -258,7 +302,7 @@ curl -v \
    -d "{
       \"status\": \"1 = backlog\",
       \"deadline\": \"2024-08-31T22:08:36.367Z\",
-      \"epic\": \"frontend\",
+      \"parentId\": \"${ISSUE_FRONTEND_ID}\",
       \"description\": \"build a client (hopefully, a CLI tool combined with \`jq\`)\"
    }" \
    localhost:5000/api/v1/issues \
@@ -276,7 +320,7 @@ curl -v \
    -d "{
       \"status\": \"2 = selected\",
       \"deadline\": \"2024-08-31T23:08:36.367Z\",
-      \"epic\": \"backend\",
+      \"parentId\": \"${ISSUE_BACKEND_ID}\",
       \"description\": \"containerize the backend\"
    }" \
    localhost:5000/api/v1/issues \
@@ -285,14 +329,10 @@ curl -v \
 # ...
 < HTTP/1.1 201 Created
 # ...
-```
 
 
 
-```bash
-export ISSUE_3_ID=<the-_id-present-in-the-preceding-HTTP-response>
-
-export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_3_ID-but-with-the-last-character-changed-to-another-hexadecimal-digit>
+export ISSUE_5_ID=<the-_id-present-in-the-preceding-HTTP-response>
 ```
 
 
@@ -314,34 +354,52 @@ curl -v \
       "last" : "/api/v1/issues?perPage=100&page=1",
       "next" : null,
       "prev" : null,
-      "total" : 3
+      "total" : 5
    },
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d4bc0775ddfdd6c15a594f",
-         "createdAt" : "2024-09-01T19:09:59.779Z",
-         "deadline" : "2024-08-31T21:08:36.367Z",
-         "description" : "convert the `epic` field to a `parentId` field",
-         "epic" : "backend",
+         "_id" : "66d53901268394815f77a7eb",
+         "createdAt" : "2024-09-02T04:03:13.830Z",
+         "deadline" : "2024-09-08T21:08:36.367Z",
+         "description" : "backend",
+         "parentId" : null,
          "status" : "3 = in progress"
       },
       {
          "__v" : 0,
-         "_id" : "66d4bc1675ddfdd6c15a5951",
-         "createdAt" : "2024-09-01T19:10:14.645Z",
-         "deadline" : "2024-08-31T22:08:36.367Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
+         "_id" : "66d53ab6cfe29c33e5c216cf",
+         "createdAt" : "2024-09-02T04:10:30.515Z",
+         "deadline" : "2024-09-15T21:08:36.367Z",
+         "description" : "frontend",
+         "parentId" : null,
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66d4bc2075ddfdd6c15a5953",
-         "createdAt" : "2024-09-01T19:10:24.140Z",
+         "_id" : "66d53b08cfe29c33e5c216d2",
+         "createdAt" : "2024-09-02T04:11:52.108Z",
+         "deadline" : "2024-08-31T21:08:36.367Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "parentId" : "66d53901268394815f77a7eb",
+         "status" : "3 = in progress"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d53bb2cfe29c33e5c216d5",
+         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "status" : "1 = backlog"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d53bd1cfe29c33e5c216d8",
+         "createdAt" : "2024-09-02T04:15:13.791Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "epic" : "backend",
+         "parentId" : "66d53901268394815f77a7eb",
          "status" : "2 = selected"
       }
    ]
@@ -350,7 +408,7 @@ curl -v \
 
 ```bash
 curl -v \
-   localhost:5000/api/v1/issues?epic=frontend \
+   localhost:5000/api/v1/issues?parentId=${ISSUE_FRONTEND_ID} \
    | json_pp
 
 # ...
@@ -358,9 +416,9 @@ curl -v \
 # ...
 {
    "meta" : {
-      "curr" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
-      "first" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
-      "last" : "/api/v1/issues?epic=frontend&perPage=100&page=1",
+      "curr" : "/api/v1/issues?parentId=66d53ab6cfe29c33e5c216cf&perPage=100&page=1",
+      "first" : "/api/v1/issues?parentId=66d53ab6cfe29c33e5c216cf&perPage=100&page=1",
+      "last" : "/api/v1/issues?parentId=66d53ab6cfe29c33e5c216cf&perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 1
@@ -368,11 +426,11 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d4bc1675ddfdd6c15a5951",
-         "createdAt" : "2024-09-01T19:10:14.645Z",
+         "_id" : "66d53bb2cfe29c33e5c216d5",
+         "createdAt" : "2024-09-02T04:14:42.362Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
+         "parentId" : "66d53ab6cfe29c33e5c216cf",
          "status" : "1 = backlog"
       }
    ]
@@ -396,25 +454,34 @@ curl -v \
       "last" : "/api/v1/issues?status=%5Bobject+Object%5D&perPage=100&page=1",
       "next" : null,
       "prev" : null,
-      "total" : 2
+      "total" : 3
    },
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d4bc1675ddfdd6c15a5951",
-         "createdAt" : "2024-09-01T19:10:14.645Z",
-         "deadline" : "2024-08-31T22:08:36.367Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
+         "_id" : "66d53ab6cfe29c33e5c216cf",
+         "createdAt" : "2024-09-02T04:10:30.515Z",
+         "deadline" : "2024-09-15T21:08:36.367Z",
+         "description" : "frontend",
+         "parentId" : null,
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66d4bc2075ddfdd6c15a5953",
-         "createdAt" : "2024-09-01T19:10:24.140Z",
+         "_id" : "66d53bb2cfe29c33e5c216d5",
+         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "status" : "1 = backlog"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d53bd1cfe29c33e5c216d8",
+         "createdAt" : "2024-09-02T04:15:13.791Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "epic" : "backend",
+         "parentId" : "66d53901268394815f77a7eb",
          "status" : "2 = selected"
       }
    ]
@@ -436,21 +503,31 @@ curl -v \
       "last" : "/api/v1/issues?select=description%2Cstatus&perPage=100&page=1",
       "next" : null,
       "prev" : null,
-      "total" : 3
+      "total" : 5
    },
    "resources" : [
       {
-         "_id" : "66d4bc0775ddfdd6c15a594f",
+         "_id" : "66d53901268394815f77a7eb",
+         "description" : "backend",
+         "status" : "3 = in progress"
+      },
+      {
+         "_id" : "66d53ab6cfe29c33e5c216cf",
+         "description" : "frontend",
+         "status" : "1 = backlog"
+      },
+      {
+         "_id" : "66d53b08cfe29c33e5c216d2",
          "description" : "convert the `epic` field to a `parentId` field",
          "status" : "3 = in progress"
       },
       {
-         "_id" : "66d4bc1675ddfdd6c15a5951",
+         "_id" : "66d53bb2cfe29c33e5c216d5",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "status" : "1 = backlog"
       },
       {
-         "_id" : "66d4bc2075ddfdd6c15a5953",
+         "_id" : "66d53bd1cfe29c33e5c216d8",
          "description" : "containerize the backend",
          "status" : "2 = selected"
       }
@@ -473,34 +550,52 @@ curl -v \
       "last" : "/api/v1/issues?sort=-status&perPage=100&page=1",
       "next" : null,
       "prev" : null,
-      "total" : 3
+      "total" : 5
    },
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d4bc0775ddfdd6c15a594f",
-         "createdAt" : "2024-09-01T19:09:59.779Z",
-         "deadline" : "2024-08-31T21:08:36.367Z",
-         "description" : "convert the `epic` field to a `parentId` field",
-         "epic" : "backend",
+         "_id" : "66d53901268394815f77a7eb",
+         "createdAt" : "2024-09-02T04:03:13.830Z",
+         "deadline" : "2024-09-08T21:08:36.367Z",
+         "description" : "backend",
+         "parentId" : null,
          "status" : "3 = in progress"
       },
       {
          "__v" : 0,
-         "_id" : "66d4bc2075ddfdd6c15a5953",
-         "createdAt" : "2024-09-01T19:10:24.140Z",
+         "_id" : "66d53b08cfe29c33e5c216d2",
+         "createdAt" : "2024-09-02T04:11:52.108Z",
+         "deadline" : "2024-08-31T21:08:36.367Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "parentId" : "66d53901268394815f77a7eb",
+         "status" : "3 = in progress"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d53bd1cfe29c33e5c216d8",
+         "createdAt" : "2024-09-02T04:15:13.791Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "epic" : "backend",
+         "parentId" : "66d53901268394815f77a7eb",
          "status" : "2 = selected"
       },
       {
          "__v" : 0,
-         "_id" : "66d4bc1675ddfdd6c15a5951",
-         "createdAt" : "2024-09-01T19:10:14.645Z",
+         "_id" : "66d53ab6cfe29c33e5c216cf",
+         "createdAt" : "2024-09-02T04:10:30.515Z",
+         "deadline" : "2024-09-15T21:08:36.367Z",
+         "description" : "frontend",
+         "parentId" : null,
+         "status" : "1 = backlog"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d53bb2cfe29c33e5c216d5",
+         "createdAt" : "2024-09-02T04:14:42.362Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
+         "parentId" : "66d53ab6cfe29c33e5c216cf",
          "status" : "1 = backlog"
       }
    ]
@@ -522,34 +617,52 @@ curl -v \
       "last" : "/api/v1/issues?sort=status&perPage=100&page=1",
       "next" : null,
       "prev" : null,
-      "total" : 3
+      "total" : 5
    },
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d4bc1675ddfdd6c15a5951",
-         "createdAt" : "2024-09-01T19:10:14.645Z",
-         "deadline" : "2024-08-31T22:08:36.367Z",
-         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "epic" : "frontend",
+         "_id" : "66d53ab6cfe29c33e5c216cf",
+         "createdAt" : "2024-09-02T04:10:30.515Z",
+         "deadline" : "2024-09-15T21:08:36.367Z",
+         "description" : "frontend",
+         "parentId" : null,
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66d4bc2075ddfdd6c15a5953",
-         "createdAt" : "2024-09-01T19:10:24.140Z",
+         "_id" : "66d53bb2cfe29c33e5c216d5",
+         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "status" : "1 = backlog"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d53bd1cfe29c33e5c216d8",
+         "createdAt" : "2024-09-02T04:15:13.791Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "epic" : "backend",
+         "parentId" : "66d53901268394815f77a7eb",
          "status" : "2 = selected"
       },
       {
          "__v" : 0,
-         "_id" : "66d4bc0775ddfdd6c15a594f",
-         "createdAt" : "2024-09-01T19:09:59.779Z",
+         "_id" : "66d53901268394815f77a7eb",
+         "createdAt" : "2024-09-02T04:03:13.830Z",
+         "deadline" : "2024-09-08T21:08:36.367Z",
+         "description" : "backend",
+         "parentId" : null,
+         "status" : "3 = in progress"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d53b08cfe29c33e5c216d2",
+         "createdAt" : "2024-09-02T04:11:52.108Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
-         "epic" : "backend",
+         "parentId" : "66d53901268394815f77a7eb",
          "status" : "3 = in progress"
       }
    ]
@@ -568,20 +681,29 @@ curl -v \
    "meta" : {
       "curr" : "/api/v1/issues?perPage=2&page=2",
       "first" : "/api/v1/issues?perPage=2&page=1",
-      "last" : "/api/v1/issues?perPage=2&page=2",
-      "next" : null,
+      "last" : "/api/v1/issues?perPage=2&page=3",
+      "next" : "/api/v1/issues?perPage=2&page=3",
       "prev" : "/api/v1/issues?perPage=2&page=1",
-      "total" : 3
+      "total" : 5
    },
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d4bc2075ddfdd6c15a5953",
-         "createdAt" : "2024-09-01T19:10:24.140Z",
-         "deadline" : "2024-08-31T23:08:36.367Z",
-         "description" : "containerize the backend",
-         "epic" : "backend",
-         "status" : "2 = selected"
+         "_id" : "66d53b08cfe29c33e5c216d2",
+         "createdAt" : "2024-09-02T04:11:52.108Z",
+         "deadline" : "2024-08-31T21:08:36.367Z",
+         "description" : "convert the `epic` field to a `parentId` field",
+         "parentId" : "66d53901268394815f77a7eb",
+         "status" : "3 = in progress"
+      },
+      {
+         "__v" : 0,
+         "_id" : "66d53bb2cfe29c33e5c216d5",
+         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "deadline" : "2024-08-31T22:08:36.367Z",
+         "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
+         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "status" : "1 = backlog"
       }
    ]
 }
@@ -619,7 +741,7 @@ curl -v \
 
 ```bash
 curl -v \
-   localhost:5000/api/v1/issues/${ISSUE_3_ID} \
+   localhost:5000/api/v1/issues/${ISSUE_5_ID} \
    | json_pp
 
 # ...
@@ -627,11 +749,11 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d4bc2075ddfdd6c15a5953",
-   "createdAt" : "2024-09-01T19:10:24.140Z",
+   "_id" : "66d53bd1cfe29c33e5c216d8",
+   "createdAt" : "2024-09-02T04:15:13.791Z",
    "deadline" : "2024-08-31T23:08:36.367Z",
    "description" : "containerize the backend",
-   "epic" : "backend",
+   "parentId" : "66d53901268394815f77a7eb",
    "status" : "2 = selected"
 }
 ```
@@ -675,7 +797,7 @@ curl -v \
    -d "{
       \"status\": \"3 = in progress\"
    }" \
-   localhost:5000/api/v1/issues/${ISSUE_3_ID} \
+   localhost:5000/api/v1/issues/${ISSUE_5_ID} \
    | json_pp
 
 # ...
@@ -683,11 +805,11 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66d4bc2075ddfdd6c15a5953",
-   "createdAt" : "2024-09-01T19:10:24.140Z",
+   "_id" : "66d53bd1cfe29c33e5c216d8",
+   "createdAt" : "2024-09-02T04:15:13.791Z",
    "deadline" : "2024-08-31T23:08:36.367Z",
    "description" : "containerize the backend",
-   "epic" : "backend",
+   "parentId" : "66d53901268394815f77a7eb",
    "status" : "3 = in progress"
 }
 ```
@@ -727,7 +849,7 @@ curl -v \
 ```bash
 curl -v \
    -X DELETE \
-   localhost:5000/api/v1/issues/${ISSUE_3_ID}
+   localhost:5000/api/v1/issues/${ISSUE_5_ID}
 
 # ...
 < HTTP/1.1 204 No Content

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -4,7 +4,10 @@ const request = require('supertest');
 
 const app = require('../src/app');
 const Issue = require('../src/models');
-const { decodeQueryStringWithinUrl } = require('../src/utilities');
+const {
+  corruptIdOfMongooseObject,
+  decodeQueryStringWithinUrl,
+} = require('../src/utilities');
 
 console.log('process.env.HOME =', process.env.HOME);
 console.log('process.env.LD_LIBRARY_PATH =', process.env.LD_LIBRARY_PATH);
@@ -122,14 +125,7 @@ describe('POST /api/v1/issues', () => {
     // Arrange.
     const issue = await Issue.create(JSON_4_ISSUE_EPIC_1);
 
-    // TODO: (2024/09/02, 05:16)
-    //      the following code-block is duplicated -
-    //      extract it into a utility function
-    const issueId = issue._id.toString();
-    const notLastDigitOfId =
-      issueId.charAt(issueId.length - 1) == '0' ? '1' : '0';
-    const nonexistentId =
-      issueId.slice(0, issueId.length - 1) + notLastDigitOfId;
+    const nonexistentId = corruptIdOfMongooseObject(issue);
 
     // Act.
     const response = await request(app)
@@ -586,11 +582,7 @@ describe('PUT /api/v1/issues/:id', () => {
       description: 'code cvrg reports in HTML',
     });
 
-    const issueId = issue._id.toString();
-    const notLastDigitOfId =
-      issueId.charAt(issueId.length - 1) == '0' ? '1' : '0';
-    const nonexistentId =
-      issueId.slice(0, issueId.length - 1) + notLastDigitOfId;
+    const nonexistentId = corruptIdOfMongooseObject(issue);
 
     // Act.
     const response = await request(app).put(`/api/v1/issues/${nonexistentId}`);
@@ -662,11 +654,7 @@ describe('DELETE /api/v1/issues/:id', () => {
       description: 'generate code coverage reports in HTML format',
     });
 
-    const issueId = issue._id.toString();
-    const notLastDigitOfId =
-      issueId.charAt(issueId.length - 1) == '0' ? '1' : '0';
-    const nonexistentId =
-      issueId.slice(0, issueId.length - 1) + notLastDigitOfId;
+    const nonexistentId = corruptIdOfMongooseObject(issue);
 
     // Act.
     const response = await request(app).delete(

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -270,13 +270,13 @@ describe('GET /api/v1/issues', () => {
       const issueEpic1 = await Issue.create(JSON_4_ISSUE_EPIC_1);
       const issueEpic2 = await Issue.create(JSON_4_ISSUE_EPIC_2);
 
-      // TODO: (2024/09/02, 05:34)
-      //      extract `issueEpic1._id.toString()` into a its own variable
+      const issueEpic1Id = issueEpic1._id.toString();
+
       const issue1 = await Issue.create({
         status: '1 = backlog',
         deadline: new Date('2024-08-31T21:43:31.696Z'),
         description: 'containerize the backend',
-        parentId: issueEpic1._id.toString(),
+        parentId: issueEpic1Id,
       });
 
       const issue2 = await Issue.create({
@@ -291,12 +291,12 @@ describe('GET /api/v1/issues', () => {
         status: '1 = backlog',
         deadline: new Date('2024-08-31T23:43:31.696Z'),
         description: 'convert the "epic" field to a "parentId" field',
-        parentId: issueEpic1._id.toString(),
+        parentId: issueEpic1Id,
       });
 
       // Act.
       const response = await request(app).get(
-        `/api/v1/issues?parentId=${issueEpic1._id.toString()}`
+        `/api/v1/issues?parentId=${issueEpic1Id}`
       );
 
       // Assert.
@@ -305,11 +305,11 @@ describe('GET /api/v1/issues', () => {
       expect(response.body).toEqual({
         meta: {
           total: 2,
-          first: `/api/v1/issues?parentId=${issueEpic1._id.toString()}&perPage=100&page=1`,
+          first: `/api/v1/issues?parentId=${issueEpic1Id}&perPage=100&page=1`,
           prev: null,
-          curr: `/api/v1/issues?parentId=${issueEpic1._id.toString()}&perPage=100&page=1`,
+          curr: `/api/v1/issues?parentId=${issueEpic1Id}&perPage=100&page=1`,
           next: null,
-          last: `/api/v1/issues?parentId=${issueEpic1._id.toString()}&perPage=100&page=1`,
+          last: `/api/v1/issues?parentId=${issueEpic1Id}&perPage=100&page=1`,
         },
         resources: [
           {
@@ -319,7 +319,7 @@ describe('GET /api/v1/issues', () => {
             status: '1 = backlog',
             deadline: '2024-08-31T21:43:31.696Z',
             description: 'containerize the backend',
-            parentId: issueEpic1._id.toString(),
+            parentId: issueEpic1Id,
           },
           {
             __v: expect.anything(),
@@ -328,7 +328,7 @@ describe('GET /api/v1/issues', () => {
             status: '1 = backlog',
             deadline: '2024-08-31T23:43:31.696Z',
             description: 'convert the "epic" field to a "parentId" field',
-            parentId: issueEpic1._id.toString(),
+            parentId: issueEpic1Id,
           },
         ],
       });
@@ -681,31 +681,31 @@ describe('DELETE /api/v1/issues/:id', () => {
   });
 
   test(
-    'if a valid ID is provider' +
+    'if a valid ID is provided' +
       ' but there exist issues whose `parentId` equals the provided one,' +
       ' should return 400',
     async () => {
       // Arrange.
       const issueEpic1 = await Issue.create(JSON_4_ISSUE_EPIC_1);
 
-      // TODO: (2024/09/02, 22:30)
-      //      extract `issueEpic1._id.toString()` into a its own variable
+      const issueEpic1Id = issueEpic1._id.toString();
+
       const issue1 = await Issue.create({
         status: '1 = backlog',
         deadline: new Date('2024-08-31T21:43:31.696Z'),
         description: 'containerize the backend',
-        parentId: issueEpic1._id.toString(),
+        parentId: issueEpic1Id,
       });
       const issue2 = await Issue.create({
         status: '1 = backlog',
         deadline: new Date('2024-08-31T23:43:31.696Z'),
         description: 'convert the "epic" field to a "parentId" field',
-        parentId: issueEpic1._id.toString(),
+        parentId: issueEpic1Id,
       });
 
       // Act.
       const response = await request(app).delete(
-        `/api/v1/issues/${issueEpic1._id.toString()}`
+        `/api/v1/issues/${issueEpic1Id}`
       );
 
       // Assert.
@@ -717,7 +717,7 @@ describe('DELETE /api/v1/issues/:id', () => {
           ' whose `parentId` points to the targeted issue',
       });
 
-      const issueEpic1StillExists = await Issue.findById(issueEpic1._id);
+      const issueEpic1StillExists = await Issue.findById(issueEpic1Id);
       expect(issueEpic1StillExists.toJSON()).toEqual(issueEpic1.toJSON());
     }
   );

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -11,9 +11,9 @@ console.log('process.env.LD_LIBRARY_PATH =', process.env.LD_LIBRARY_PATH);
 
 let mongoMemoryServer;
 
-// For debugging, set the timeout for each test case to the specified amount of time.
-const MILLISECONDS_IN_FIVE_MINUTES = 5 * 60 * 1000;
-jest.setTimeout(MILLISECONDS_IN_FIVE_MINUTES);
+// // For debugging, set the timeout for each test case to the specified amount of time.
+// const MILLISECONDS_IN_FIVE_MINUTES = 5 * 60 * 1000;
+// jest.setTimeout(MILLISECONDS_IN_FIVE_MINUTES);
 
 beforeAll(async () => {
   mongoMemoryServer = await mms.MongoMemoryServer.create();
@@ -724,22 +724,15 @@ describe('DELETE /api/v1/issues/:id', () => {
 
       // Assert.
       expect(response.status).toEqual(400);
-      // TODO: (2024/09/02, 22:54)
-      //      this test fails at the preceding statement
-      //
-      //      that is a bug
-      //
-      //      this automated test that catches the bug
-      //
-      //      fix the bug, getting this test to PASS
       expect(response.body).toEqual({
-        message: 'TBD',
+        message:
+          'Cannot delete the targeted issue,' +
+          ` because there exist 2 other issues` +
+          ' whose `parentId` points to the targeted issue',
       });
 
-      const issueEpic1StillExists = await Issue.findById(issue2._id);
+      const issueEpic1StillExists = await Issue.findById(issueEpic1._id);
       expect(issueEpic1StillExists.toJSON()).toEqual(issueEpic1.toJSON());
-
-      expect(2 + 2).toEqual(5);
     }
   );
 

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -80,8 +80,100 @@ describe('POST /api/v1/issues', () => {
       createdAt: '2024-08-17T09:00:00.000Z',
       status: '1 = backlog',
       deadline: '2024-08-19T09:00:00.000Z',
-      epic: 'backend',
+      parentId: null,
       description: 'containerize the backend',
+    });
+  });
+
+  test('if "parentId" is invalid, should return 400', async () => {
+    // Arrange.
+    const issueId = 'this is an invalid issue ID';
+
+    // Act.
+    const response = await request(app)
+      .post('/api/v1/issues')
+      .send({
+        status: '1 = backlog',
+        deadline: new Date('2024-09-02T02:56:42.053Z'),
+        parentId: issueId,
+        description: 'implement a rudimentary authentication sub-system',
+      });
+
+    // Assert.
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({
+      message: 'The value provided for "parentId" is invalid',
+    });
+  });
+
+  test('if "parentId" is non-existent, should returnd 400', async () => {
+    // Arrange.
+    // TODO: (2024/09/02, 05:14)
+    //      the JSON object below is duplicated -
+    //      extract it into a constant somehow
+    const issue = await Issue.create({
+      status: '3 = in progress',
+      deadline: new Date('2024-09-02T02:45:36.214Z'),
+      description: 'backend',
+    });
+
+    // TODO: (2024/09/02, 05:16)
+    //      the following code-block is duplicated -
+    //      extract it into a utility function
+    const issueId = issue._id.toString();
+    const notLastDigitOfId =
+      issueId.charAt(issueId.length - 1) == '0' ? '1' : '0';
+    const nonexistentId =
+      issueId.slice(0, issueId.length - 1) + notLastDigitOfId;
+
+    // Act.
+    const response = await request(app)
+      .post(`/api/v1/issues`)
+      .send({
+        status: '1 = backlog',
+        deadline: new Date('2024-09-02T02:56:42.053Z'),
+        parentId: nonexistentId,
+        description: 'implement a rudimentary authentication sub-system',
+      });
+
+    // Assert.
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({
+      message: 'The value provided for `parentId` is non-existent',
+    });
+  });
+
+  test('if "status" and "description" and "parentId", should return 201', async () => {
+    // Arrange.
+    const issue = await Issue.create({
+      status: '3 = in progress',
+      deadline: new Date('2024-09-02T02:45:36.214Z'),
+      description: 'backend',
+    });
+
+    // Act.
+    const response = await request(app)
+      .post('/api/v1/issues')
+      .send({
+        status: '1 = backlog',
+        deadline: new Date('2024-09-02T02:48:26.383Z'),
+        parentId: issue._id.toString(),
+        description: 'implement a rudimentary authentication sub-system',
+      });
+
+    // Assert.
+    expect(response.status).toEqual(201);
+    expect(response.headers.location).toEqual(
+      `/api/v1/issues/${response.body._id}`
+    );
+    expect(response.body).toEqual({
+      __v: expect.anything(),
+      _id: expect.anything(),
+      createdAt: expect.anything(),
+      status: '1 = backlog',
+      deadline: '2024-09-02T02:48:26.383Z',
+      parentId: issue._id.toString(),
+      description: 'implement a rudimentary authentication sub-system',
     });
   });
 });
@@ -150,6 +242,7 @@ describe('GET /api/v1/issues', () => {
             createdAt: expect.anything(),
             status: '3 = in progress',
             deadline: '2024-08-20T21:07:45.759Z',
+            parentId: null,
             description: 'write tests for the other request-handling functions',
           },
           {
@@ -158,6 +251,7 @@ describe('GET /api/v1/issues', () => {
             createdAt: expect.anything(),
             status: '1 = backlog',
             deadline: '2024-08-20T21:08:31.345Z',
+            parentId: null,
             description:
               'switch from `const express = require(express)` to `import express from "express";"',
           },
@@ -168,15 +262,28 @@ describe('GET /api/v1/issues', () => {
 
   test(
     'if there are Issue resource' +
-      ' and the URL query parameters represent a request filtering for filtering,' +
+      ' and the URL query parameters represent a request for filtering,' +
       ' should return 200, a correct total, and representation of the resources',
     async () => {
       // Arrange.
+      const issueEpic1 = await Issue.create({
+        status: '3 = in progress',
+        deadline: new Date('2024-09-02T02:45:36.214Z'),
+        description: 'backend',
+      });
+      const issueEpic2 = await Issue.create({
+        status: '1 = backlog',
+        deadline: new Date('2024-09-02T03:28:39.611Z'),
+        description: 'frontend',
+      });
+
+      // TODO: (2024/09/02, 05:34)
+      //      extract `issueEpic1._id.toString()` into a its own variable
       const issue1 = await Issue.create({
         status: '1 = backlog',
         deadline: new Date('2024-08-31T21:43:31.696Z'),
         description: 'containerize the backend',
-        epic: 'backend',
+        parentId: issueEpic1._id.toString(),
       });
 
       const issue2 = await Issue.create({
@@ -184,18 +291,20 @@ describe('GET /api/v1/issues', () => {
         deadline: new Date('2024-08-31T22:43:31.696Z'),
         description:
           'build a client (hopefully, a CLI tool combined with "jq")',
-        epic: 'frontend',
+        parentId: issueEpic2._id.toString(),
       });
 
       const issue3 = await Issue.create({
         status: '1 = backlog',
         deadline: new Date('2024-08-31T23:43:31.696Z'),
         description: 'convert the "epic" field to a "parentId" field',
-        epic: 'backend',
+        parentId: issueEpic1._id.toString(),
       });
 
       // Act.
-      const response = await request(app).get('/api/v1/issues?epic=backend');
+      const response = await request(app).get(
+        `/api/v1/issues?parentId=${issueEpic1._id.toString()}`
+      );
 
       // Assert.
       expect(response.status).toEqual(200);
@@ -203,11 +312,11 @@ describe('GET /api/v1/issues', () => {
       expect(response.body).toEqual({
         meta: {
           total: 2,
-          first: '/api/v1/issues?epic=backend&perPage=100&page=1',
+          first: `/api/v1/issues?parentId=${issueEpic1._id.toString()}&perPage=100&page=1`,
           prev: null,
-          curr: '/api/v1/issues?epic=backend&perPage=100&page=1',
+          curr: `/api/v1/issues?parentId=${issueEpic1._id.toString()}&perPage=100&page=1`,
           next: null,
-          last: '/api/v1/issues?epic=backend&perPage=100&page=1',
+          last: `/api/v1/issues?parentId=${issueEpic1._id.toString()}&perPage=100&page=1`,
         },
         resources: [
           {
@@ -217,7 +326,7 @@ describe('GET /api/v1/issues', () => {
             status: '1 = backlog',
             deadline: '2024-08-31T21:43:31.696Z',
             description: 'containerize the backend',
-            epic: 'backend',
+            parentId: issueEpic1._id.toString(),
           },
           {
             __v: expect.anything(),
@@ -226,7 +335,7 @@ describe('GET /api/v1/issues', () => {
             status: '1 = backlog',
             deadline: '2024-08-31T23:43:31.696Z',
             description: 'convert the "epic" field to a "parentId" field',
-            epic: 'backend',
+            parentId: issueEpic1._id.toString(),
           },
         ],
       });
@@ -319,6 +428,7 @@ describe('GET /api/v1/issues', () => {
           createdAt: expect.anything(),
           status: '3 = in progress',
           deadline: '2024-08-31T09:59:50.783Z',
+          parentId: null,
           description:
             'enable the handler for GET requests' +
             ' to select only certain fields, to sort, and to paginate',
@@ -329,6 +439,7 @@ describe('GET /api/v1/issues', () => {
           createdAt: expect.anything(),
           status: '2 = selected',
           deadline: '2024-08-31T09:58:50.783Z',
+          parentId: null,
           description:
             'supplement the pagination-info bundle with URLs for "first" and "last"',
         },
@@ -405,6 +516,7 @@ describe('GET /api/v1/issues', () => {
             createdAt: expect.anything(),
             status: '1 = backlog',
             deadline: '2024-09-03T16:41:47.722Z',
+            parentId: null,
             description: 'carry out step 3',
           },
         ],
@@ -431,8 +543,7 @@ describe('GET /api/v1/issues/:id', () => {
     const issue = await Issue.create({
       status: '1 = backlog',
       deadline,
-      epic: 'ease of development',
-      description: 'introduce code coverage reports in HTML format',
+      description: 'ease of development',
     });
 
     // Act.
@@ -446,9 +557,8 @@ describe('GET /api/v1/issues/:id', () => {
       createdAt: issue.createdAt.toISOString(),
       status: '1 = backlog',
       deadline: deadline.toISOString(),
-      // finishedAt: null,
-      epic: 'ease of development',
-      description: 'introduce code coverage reports in HTML format',
+      parentId: null,
+      description: 'ease of development',
     });
   });
 });
@@ -523,6 +633,7 @@ describe('PUT /api/v1/issues/:id', () => {
       createdAt: expect.anything(),
       status: '2 = selected',
       deadline: '2024-08-20T20:38:18.162Z',
+      parentId: null,
       description: 'generate code coverage reports in HTML format',
     });
   });

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -267,6 +267,7 @@ describe('GET /api/v1/issues', () => {
       const issueEpic2 = await Issue.create(JSON_4_ISSUE_EPIC_2);
 
       const issueEpic1Id = issueEpic1._id.toString();
+      const issueEpic2Id = issueEpic2._id.toString();
 
       const issue1 = await Issue.create({
         status: '1 = backlog',
@@ -291,14 +292,14 @@ describe('GET /api/v1/issues', () => {
       });
 
       // Act.
-      const response = await request(app).get(
+      const response1 = await request(app).get(
         `/api/v1/issues?parentId=${issueEpic1Id}`
       );
 
       // Assert.
-      expect(response.status).toEqual(200);
+      expect(response1.status).toEqual(200);
 
-      expect(response.body).toEqual({
+      expect(response1.body).toEqual({
         meta: {
           total: 2,
           first: `/api/v1/issues?parentId=${issueEpic1Id}&perPage=100&page=1`,
@@ -328,6 +329,53 @@ describe('GET /api/v1/issues', () => {
           },
         ],
       });
+
+      // Act.
+      const response2 = await request(app).get('/api/v1/issues?parentId=null');
+
+      // Assert.
+      expect(response2.status).toEqual(200);
+
+      const expectedBodyOfResponse2 = {
+        meta: {
+          total: 2,
+          first: '/api/v1/issues?parentId=null&perPage=100&page=1',
+          prev: null,
+          curr: '/api/v1/issues?parentId=null&perPage=100&page=1',
+          next: null,
+          last: '/api/v1/issues?parentId=null&perPage=100&page=1',
+        },
+        resources: [
+          {
+            __v: expect.anything(),
+            _id: issueEpic1Id,
+            createdAt: expect.anything(),
+            status: '3 = in progress',
+            deadline: '2024-09-02T02:45:36.214Z',
+            description: 'backend',
+            parentId: null,
+          },
+          {
+            __v: expect.anything(),
+            _id: issueEpic2Id,
+            createdAt: expect.anything(),
+            status: '1 = backlog',
+            deadline: '2024-09-02T03:28:39.611Z',
+            description: 'frontend',
+            parentId: null,
+          },
+        ],
+      };
+      expect(response2.body).toEqual(expectedBodyOfResponse2);
+
+      // Act.
+      const response3 = await request(app).get('/api/v1/issues?parentId=');
+
+      // Assert.
+      expect(response3.status).toEqual(200);
+
+      const expectedBodyOfResponse3 = { ...expectedBodyOfResponse2 };
+      expect(response3.body).toEqual(expectedBodyOfResponse3);
     }
   );
 

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -15,6 +15,18 @@ let mongoMemoryServer;
 // const MILLISECONDS_IN_FIVE_MINUTES = 5 * 60 * 1000;
 // jest.setTimeout(MILLISECONDS_IN_FIVE_MINUTES);
 
+const JSON_4_ISSUE_EPIC_1 = {
+  status: '3 = in progress',
+  deadline: new Date('2024-09-02T02:45:36.214Z'),
+  description: 'backend',
+};
+
+const JSON_4_ISSUE_EPIC_2 = {
+  status: '1 = backlog',
+  deadline: new Date('2024-09-02T03:28:39.611Z'),
+  description: 'frontend',
+};
+
 beforeAll(async () => {
   mongoMemoryServer = await mms.MongoMemoryServer.create();
   const uri = mongoMemoryServer.getUri();
@@ -108,14 +120,7 @@ describe('POST /api/v1/issues', () => {
 
   test('if "parentId" is non-existent, should returnd 400', async () => {
     // Arrange.
-    // TODO: (2024/09/02, 05:14)
-    //      the JSON object below is duplicated -
-    //      extract it into a constant somehow
-    const issue = await Issue.create({
-      status: '3 = in progress',
-      deadline: new Date('2024-09-02T02:45:36.214Z'),
-      description: 'backend',
-    });
+    const issue = await Issue.create(JSON_4_ISSUE_EPIC_1);
 
     // TODO: (2024/09/02, 05:16)
     //      the following code-block is duplicated -
@@ -145,11 +150,7 @@ describe('POST /api/v1/issues', () => {
 
   test('if "status" and "description" and "parentId", should return 201', async () => {
     // Arrange.
-    const issue = await Issue.create({
-      status: '3 = in progress',
-      deadline: new Date('2024-09-02T02:45:36.214Z'),
-      description: 'backend',
-    });
+    const issue = await Issue.create(JSON_4_ISSUE_EPIC_1);
 
     // Act.
     const response = await request(app)
@@ -266,16 +267,8 @@ describe('GET /api/v1/issues', () => {
       ' should return 200, a correct total, and representation of the resources',
     async () => {
       // Arrange.
-      const issueEpic1 = await Issue.create({
-        status: '3 = in progress',
-        deadline: new Date('2024-09-02T02:45:36.214Z'),
-        description: 'backend',
-      });
-      const issueEpic2 = await Issue.create({
-        status: '1 = backlog',
-        deadline: new Date('2024-09-02T03:28:39.611Z'),
-        description: 'frontend',
-      });
+      const issueEpic1 = await Issue.create(JSON_4_ISSUE_EPIC_1);
+      const issueEpic2 = await Issue.create(JSON_4_ISSUE_EPIC_2);
 
       // TODO: (2024/09/02, 05:34)
       //      extract `issueEpic1._id.toString()` into a its own variable
@@ -693,14 +686,7 @@ describe('DELETE /api/v1/issues/:id', () => {
       ' should return 400',
     async () => {
       // Arrange.
-      // TODO: (2024/09/02, 22:29)
-      //      the JSON object below is duplicated -
-      //      extract it into a constant somehow
-      const issueEpic1 = await Issue.create({
-        status: '3 = in progress',
-        deadline: new Date('2024-09-02T02:45:36.214Z'),
-        description: 'backend',
-      });
+      const issueEpic1 = await Issue.create(JSON_4_ISSUE_EPIC_1);
 
       // TODO: (2024/09/02, 22:30)
       //      extract `issueEpic1._id.toString()` into a its own variable

--- a/src/app.js
+++ b/src/app.js
@@ -46,8 +46,6 @@ app.post('/api/v1/issues', async (req, res) => {
   } catch (err) {
     console.error(err);
 
-    // TODO: (2024/09/02, 05:02)
-    //      shouldn't the following be 500 ?
     res.status(400).json({
       message: 'Unable to create a new issue.',
     });

--- a/src/app.js
+++ b/src/app.js
@@ -252,18 +252,6 @@ app.put('/api/v1/issues/:id', async (req, res) => {
   res.status(200).json(issue);
 });
 
-// TODO: (2024/09/02, 06:06)
-//      bug:
-//      if issue A is the parent of issue B
-//      and an HTTP client issues a request for deleting issue A,
-//      the HTTP response has a status code of 204
-//      and
-//      issue A gets deleted from the database
-//      _but_ the `parentId` of issue B remains set to the `_id` of the now-deleted issue A ;
-//
-//      write an automated test that catches the bug
-//
-//      fix the bug
 app.delete('/api/v1/issues/:id', async (req, res) => {
   let issue;
   const issueId = req.params.id;

--- a/src/app.js
+++ b/src/app.js
@@ -61,6 +61,10 @@ app.post('/api/v1/issues', async (req, res) => {
     .json(newIssue);
 });
 
+// TODO: (2024/09/02, 06:20)
+//      does this handler make it possible
+//      to obtain all Issue resources without a `parentId`?
+//      write an automated test for that scenario
 app.get('/api/v1/issues', async (req, res) => {
   let query;
 
@@ -248,6 +252,18 @@ app.put('/api/v1/issues/:id', async (req, res) => {
   res.status(200).json(issue);
 });
 
+// TODO: (2024/09/02, 06:06)
+//      bug:
+//      if issue A is the parent of issue B
+//      and an HTTP client issues a request for deleting issue A,
+//      the HTTP response has a status code of 204
+//      and
+//      issue A gets deleted from the database
+//      _but_ the `parentId` of issue B remains set to the `_id` of the now-deleted issue A ;
+//
+//      write an automated test that catches the bug
+//
+//      fix the bug
 app.delete('/api/v1/issues/:id', async (req, res) => {
   let issue;
   const issueId = req.params.id;

--- a/src/app.js
+++ b/src/app.js
@@ -59,10 +59,6 @@ app.post('/api/v1/issues', async (req, res) => {
     .json(newIssue);
 });
 
-// TODO: (2024/09/02, 06:20)
-//      does this handler make it possible
-//      to obtain all Issue resources without a `parentId`?
-//      write an automated test for that scenario
 app.get('/api/v1/issues', async (req, res) => {
   let query;
 
@@ -75,13 +71,23 @@ app.get('/api/v1/issues', async (req, res) => {
 
   const excludedParam2Value = {};
   const fieldsToExcludeFromReqQuery = ['select', 'sort', 'perPage', 'page'];
-  for (f of fieldsToExcludeFromReqQuery) {
+  for (const f of fieldsToExcludeFromReqQuery) {
     if (reqQuery[f]) {
       excludedParam2Value[f] = reqQuery[f];
     }
 
     delete reqQuery[f];
   }
+
+  // Allow for the `parentId` query parameter to be set to «a void value».
+  const nullValuesForParentId = new Set(['', 'null']);
+  if (
+    reqQuery.hasOwnProperty('parentId') &&
+    nullValuesForParentId.has(reqQuery['parentId'])
+  ) {
+    reqQuery['parentId'] = null;
+  }
+
   const queryRawStr = JSON.stringify(reqQuery);
 
   // Create the following Mongoose operators: `$in`, `$lt`, `$lte`, `$gt`, `$gte` .

--- a/src/app.js
+++ b/src/app.js
@@ -263,6 +263,26 @@ app.delete('/api/v1/issues/:id', async (req, res) => {
     });
   }
 
+  let countChildren;
+  try {
+    countChildren = await Issue.find({
+      parentId: issueId,
+    }).countDocuments();
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Failed to process your HTTP request',
+    });
+  }
+  if (countChildren > 0) {
+    res.status(400).json({
+      message:
+        'Cannot delete the targeted issue,' +
+        ` because there exist ${countChildren} other issues` +
+        ' whose `parentId` points to the targeted issue',
+    });
+    return;
+  }
+
   if (!issue) {
     return res.status(404).json({
       message: 'Resource not found',

--- a/src/app.js
+++ b/src/app.js
@@ -214,15 +214,19 @@ app.get('/api/v1/issues/:id', async (req, res) => {
   try {
     issue = await Issue.findById(issueId);
   } catch (err) {
-    return res.status(400).json({
+    res.status(400).json({
       message: 'Invalid ID provided',
     });
+
+    return;
   }
 
   if (!issue) {
-    return res.status(404).json({
+    res.status(404).json({
       message: 'Resource not found',
     });
+
+    return;
   }
 
   res.status(200).json(issue);
@@ -234,15 +238,19 @@ app.put('/api/v1/issues/:id', async (req, res) => {
   try {
     issue = await Issue.findById(issueId);
   } catch (err) {
-    return res.status(400).json({
+    res.status(400).json({
       message: 'Invalid ID provided',
     });
+
+    return;
   }
 
   if (!issue) {
-    return res.status(404).json({
+    res.status(404).json({
       message: 'Resource not found',
     });
+
+    return;
   }
 
   issue = await Issue.findByIdAndUpdate(issueId, req.body, {
@@ -258,9 +266,11 @@ app.delete('/api/v1/issues/:id', async (req, res) => {
   try {
     issue = await Issue.findById(issueId);
   } catch (err) {
-    return res.status(400).json({
+    res.status(400).json({
       message: 'Invalid ID provided',
     });
+
+    return;
   }
 
   let countChildren;
@@ -269,9 +279,11 @@ app.delete('/api/v1/issues/:id', async (req, res) => {
       parentId: issueId,
     }).countDocuments();
   } catch (err) {
-    return res.status(500).json({
+    res.status(500).json({
       message: 'Failed to process your HTTP request',
     });
+
+    return;
   }
   if (countChildren > 0) {
     res.status(400).json({
@@ -284,9 +296,11 @@ app.delete('/api/v1/issues/:id', async (req, res) => {
   }
 
   if (!issue) {
-    return res.status(404).json({
+    res.status(404).json({
       message: 'Resource not found',
     });
+
+    return;
   }
 
   await issue.deleteOne();

--- a/src/app.js
+++ b/src/app.js
@@ -17,11 +17,37 @@ if (process.env.NODE_ENV === 'development') {
 app.post('/api/v1/issues', async (req, res) => {
   let newIssue;
 
+  if (req.body.parentId) {
+    let parentIssue;
+
+    try {
+      parentIssue = await Issue.findById(req.body.parentId);
+    } catch (err) {
+      console.error(err);
+
+      res.status(400).json({
+        message: 'The value provided for "parentId" is invalid',
+      });
+
+      return;
+    }
+
+    if (!parentIssue) {
+      res.status(400).json({
+        message: 'The value provided for `parentId` is non-existent',
+      });
+
+      return;
+    }
+  }
+
   try {
     newIssue = await Issue.create(req.body);
   } catch (err) {
     console.error(err);
 
+    // TODO: (2024/09/02, 05:02)
+    //      shouldn't the following be 500 ?
     res.status(400).json({
       message: 'Unable to create a new issue.',
     });

--- a/src/models.js
+++ b/src/models.js
@@ -1,5 +1,7 @@
 const mongoose = require('mongoose');
 
+const NAME_OF_ISSUE_MODEL = 'Issue';
+
 const IssueSchema = new mongoose.Schema({
   createdAt: {
     type: Date,
@@ -24,9 +26,14 @@ const IssueSchema = new mongoose.Schema({
   finishedAt: {
     type: Date,
   },
-  // TODO: (2024/08/17, 11:27) convert the following to a nullable reference to `this._id`
-  epic: {
-    type: String,
+  parentId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: NAME_OF_ISSUE_MODEL,
+    default: null, // Allows the field to be nullable.
+    // TODO: (2024/08/28, 21:23)
+    //        find out how to create a secondary index on this field
+    //        https://mongoosejs.com/docs/guide.html#indexes
+    // index: true,
   },
   description: {
     type: String,
@@ -34,6 +41,6 @@ const IssueSchema = new mongoose.Schema({
   },
 });
 
-const Issue = new mongoose.model('Issue', IssueSchema);
+const Issue = new mongoose.model(NAME_OF_ISSUE_MODEL, IssueSchema);
 
 module.exports = Issue;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,3 +1,17 @@
+exports.corruptIdOfMongooseObject = (mongooseObj) => {
+  /*
+  Create a valid Mongoose ID
+  which, however, does not exist in a Mongoose model.
+  */
+
+  const objId = mongooseObj._id.toString();
+
+  const notLastDigitOfId = objId.charAt(objId.length - 1) == '0' ? '1' : '0';
+  const nonexistentId = objId.slice(0, objId.length - 1) + notLastDigitOfId;
+
+  return nonexistentId;
+};
+
 exports.decodeQueryStringWithinUrl = (url) => {
   const [baseUrl, queryStringRaw] = url.split('?');
 


### PR DESCRIPTION
this pull request
replaces `Issue.epic` (which was a field of `type: String`)
with `Issue.parentId` (which is a nullable reference to `Issue._id`)