### PR TITLE
Implement a minimalistic authentication sub-system

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,8 @@ MONGO_AUTHENTICATION_DATABASE=  # Set this equal to `admin` (without the backtic
 MONGO_USERNAME=  # As configuration for a user that will be created in MongoDB's "authentication database" called `admin`, set a username for said user.
 MONGO_PASSWORD=  # As configuration for a user that will be created in MongoDB's "authentication database" called `admin`, set a password for said user.
 MONGO_DATABASE=  # Set this equal to `db-4-m-j-3` (without the backticks). Full disclosure: that is _my_ recommendation. For more details on what this variable does when the MongoDB container is created, see https://hub.docker.com/_/mongo
+
+# Specify a set of Basic Authentication credentials,
+# which constitute the only mechanism for communicating with the backend application.
+BACKEND_USERNAME=
+BACKEND_PASSWORD=

--- a/.env.template
+++ b/.env.template
@@ -5,7 +5,16 @@ MONGO_USERNAME=  # As configuration for a user that will be created in MongoDB's
 MONGO_PASSWORD=  # As configuration for a user that will be created in MongoDB's "authentication database" called `admin`, set a password for said user.
 MONGO_DATABASE=  # Set this equal to `db-4-m-j-3` (without the backticks). Full disclosure: that is _my_ recommendation. For more details on what this variable does when the MongoDB container is created, see https://hub.docker.com/_/mongo
 
+# Specify a secret key, which the backend will use to generate cryptographic signatures.
+BACKEND_SECRET_KEY=
+
 # Specify a set of Basic Authentication credentials,
 # which constitute the only mechanism for communicating with the backend application.
+BACKEND_USER_ID=
 BACKEND_USERNAME=
 BACKEND_PASSWORD=
+
+# Specify a value,
+# which will be used for the `expiresIn` option accepted by the `jwt.sign` function.
+# (That option is described on https://www.npmjs.com/package/jsonwebtoken .)
+BACKEND_JWT_EXPIRES_IN=

--- a/README.md
+++ b/README.md
@@ -984,9 +984,36 @@ curl -v \
 # The body of the HTTP response is empty.
 ```
 
+
+
+revoke the access token
+and
+verify that the backend will not accept the revoked token
+
 ```bash
 curl -v \
    -X DELETE \
    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/tokens
+
+# ...
+< HTTP/1.1 204 No Content
+# ...
+# The body of the HTTP response is empty.
+
+
+
+# Repeat any one of the above-listed HTTP requests with status codes 2xx -
+# for example:
+curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+   localhost:5000/api/v1/issues \
+   | json_pp
+
+# ...
+< HTTP/1.1 401 Unauthorized
+# ...
+{
+   "message" : "Revoked access token"
+}
 ```

--- a/README.md
+++ b/README.md
@@ -201,11 +201,68 @@ in it, issue the following requests to the HTTP server:
 
 
 
-create one
+(leveraging the environment variables in your `.env` file,)
+obtain an access token
 
 ```bash
 curl -v \
    -X POST \
+   localhost:5000/api/v1/tokens \
+   | json_pp
+
+# ...
+< HTTP/1.1 400 Bad Request
+# ...
+{
+   "message" : "Missing \"Authorization\" header"
+}
+
+
+
+curl -v \
+   -X POST \
+   -u "${BACKEND_USERNAME}:${BACKEND_PASSWORD}" \
+   localhost:5000/api/v1/tokens \
+   | json_pp
+
+# ...
+< HTTP/1.1 200 OK
+# ...
+{
+   "accessToken" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTcyNTc4Mjc1MCwiZXhwIjoxNzI1NzgzNjUwfQ.gJCTyZqYbmLEIIZOf8r-nXc2WY2c1zYQnfMSvFNb5zg"
+}
+
+
+
+export ACCESS_TOKEN=<the-value-present-in-the-preceding-HTTP-response>>
+```
+
+
+
+create one `Issue`
+
+```bash
+curl -v \
+   -X POST \
+   -H "Content-Type: application/json" \
+   -d "{
+      \"status\": \"1 = backlog\"
+   }" \
+   localhost:5000/api/v1/issues \
+   | json_pp
+
+# ...
+< HTTP/1.1 400 Bad Request
+# ...
+{
+   "message" : "Missing \"Authorization\" header"
+}
+```
+
+```bash
+curl -v \
+   -X POST \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    -H "Content-Type: application/json" \
    -d "{
       \"status\": \"1 = backlog\"
@@ -224,6 +281,7 @@ curl -v \
 ```bash
 curl -v \
    -X POST \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    -H "Content-Type: application/json" \
    -d "{
       \"status\": \"3 = in progress\",
@@ -257,6 +315,7 @@ export VALID_BUT_NONEXISTENT_ISSUE_ID=<same-as-ISSUE_BACKEND_ID-but-with-the-las
 
 curl -v \
    -X POST \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    -H "Content-Type: application/json" \
    -d "{
       \"status\": \"1 = backlog\",
@@ -278,6 +337,7 @@ export ISSUE_FRONTEND_ID=<the-_id-present-in-the-preceding-HTTP-response>
 
 curl -v \
    -X POST \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    -H "Content-Type: application/json" \
    -d "{
       \"status\": \"3 = in progress\",
@@ -296,6 +356,7 @@ curl -v \
 ```bash
 curl -v \
    -X POST \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    -H "Content-Type: application/json" \
    -d "{
       \"status\": \"1 = backlog\",
@@ -314,6 +375,7 @@ curl -v \
 ```bash
 curl -v \
    -X POST \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    -H "Content-Type: application/json" \
    -d "{
       \"status\": \"2 = selected\",
@@ -335,10 +397,11 @@ export ISSUE_5_ID=<the-_id-present-in-the-preceding-HTTP-response>
 
 
 
-retrieve multiple
+retrieve multiple  `Issue`s
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues \
    | json_pp
 
@@ -406,6 +469,7 @@ curl -v \
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues?parentId=${ISSUE_FRONTEND_ID} \
    | json_pp
 
@@ -437,6 +501,7 @@ curl -v \
 
 
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues?parentId=null \
    | json_pp
 
@@ -477,6 +542,7 @@ curl -v \
 
 
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues?parentId= \
    | json_pp
 
@@ -488,6 +554,7 @@ curl -v \
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    'localhost:5000/api/v1/issues?status\[lt\]=3' \
    | json_pp
 
@@ -537,6 +604,7 @@ curl -v \
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    'localhost:5000/api/v1/issues?select=description,status' \
    | json_pp
 
@@ -584,6 +652,7 @@ curl -v \
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    'localhost:5000/api/v1/issues?sort=-status' \
    | json_pp
 
@@ -651,6 +720,7 @@ curl -v \
 
 
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    'localhost:5000/api/v1/issues?sort=status' \
    | json_pp
 
@@ -718,6 +788,7 @@ curl -v \
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    'localhost:5000/api/v1/issues?perPage=2&page=2' \
    | json_pp
 
@@ -758,10 +829,11 @@ curl -v \
 
 
 
-retrieve one
+retrieve one `Issue`
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues/17 \
    | json_pp
 
@@ -775,6 +847,7 @@ curl -v \
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
    | json_pp
 
@@ -788,6 +861,7 @@ curl -v \
 
 ```bash
 curl -v \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues/${ISSUE_5_ID} \
    | json_pp
 
@@ -812,6 +886,7 @@ update one
 ```bash
 curl -v \
    -X PUT \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues/17 \
    | json_pp
 
@@ -826,6 +901,7 @@ curl -v \
 ```bash
 curl -v \
    -X PUT \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
    | json_pp
 
@@ -840,6 +916,7 @@ curl -v \
 ```bash
 curl -v \
    -X PUT \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    -H "Content-Type: application/json" \
    -d "{
       \"status\": \"3 = in progress\"
@@ -863,11 +940,12 @@ curl -v \
 
 
 
-delete one
+delete one `Issue`
 
 ```bash
 curl -v \
    -X DELETE \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues/17 \
    | json_pp
 
@@ -882,6 +960,7 @@ curl -v \
 ```bash
 curl -v \
    -X DELETE \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues/${VALID_BUT_NONEXISTENT_ISSUE_ID} \
    | json_pp
 
@@ -896,10 +975,18 @@ curl -v \
 ```bash
 curl -v \
    -X DELETE \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
    localhost:5000/api/v1/issues/${ISSUE_5_ID}
 
 # ...
 < HTTP/1.1 204 No Content
 # ...
 # The body of the HTTP response is empty.
+```
+
+```bash
+curl -v \
+   -X DELETE \
+   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+   localhost:5000/api/v1/tokens
 ```

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ curl -v \
 < HTTP/1.1 200 OK
 # ...
 {
-   "accessToken" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTcyNTc4Mjc1MCwiZXhwIjoxNzI1NzgzNjUwfQ.gJCTyZqYbmLEIIZOf8r-nXc2WY2c1zYQnfMSvFNb5zg"
+   "accessToken" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTcyNTc5MTc0NywiZXhwIjoxNzI1NzkzMjQ3fQ.4Ts6B6PFXp9hemAdQKkh2_MhPUOp4Z-0SvJS-teZ3S4"
 }
 
 
@@ -297,8 +297,8 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66dc11fd1c3a2a743744172f",
-   "createdAt" : "2024-09-07T08:42:37.374Z",
+   "_id" : "66dd7e58e7c673746905ff27",
+   "createdAt" : "2024-09-08T10:37:12.447Z",
    "deadline" : "2024-09-08T21:08:36.367Z",
    "description" : "backend",
    "parentId" : null,
@@ -420,8 +420,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66d53901268394815f77a7eb",
-         "createdAt" : "2024-09-02T04:03:13.830Z",
+         "_id" : "66dd7e58e7c673746905ff27",
+         "createdAt" : "2024-09-08T10:37:12.447Z",
          "deadline" : "2024-09-08T21:08:36.367Z",
          "description" : "backend",
          "parentId" : null,
@@ -429,8 +429,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d53ab6cfe29c33e5c216cf",
-         "createdAt" : "2024-09-02T04:10:30.515Z",
+         "_id" : "66dd7ea5e7c673746905ff2a",
+         "createdAt" : "2024-09-08T10:38:29.616Z",
          "deadline" : "2024-09-15T21:08:36.367Z",
          "description" : "frontend",
          "parentId" : null,
@@ -438,29 +438,29 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66d53b08cfe29c33e5c216d2",
-         "createdAt" : "2024-09-02T04:11:52.108Z",
+         "_id" : "66dd7eb5e7c673746905ff2e",
+         "createdAt" : "2024-09-08T10:38:45.259Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
-         "parentId" : "66d53901268394815f77a7eb",
+         "parentId" : "66dd7e58e7c673746905ff27",
          "status" : "3 = in progress"
       },
       {
          "__v" : 0,
-         "_id" : "66d53bb2cfe29c33e5c216d5",
-         "createdAt" : "2024-09-02T04:14:42.362Z",
+         "_id" : "66dd7ebce7c673746905ff32",
+         "createdAt" : "2024-09-08T10:38:52.671Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66d53ab6cfe29c33e5c216cf",
+         "parentId" : "66dd7ea5e7c673746905ff2a",
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66d53bd1cfe29c33e5c216d8",
-         "createdAt" : "2024-09-02T04:15:13.791Z",
+         "_id" : "66dd7ec4e7c673746905ff36",
+         "createdAt" : "2024-09-08T10:39:00.513Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "parentId" : "66d53901268394815f77a7eb",
+         "parentId" : "66dd7e58e7c673746905ff27",
          "status" : "2 = selected"
       }
    ]
@@ -478,9 +478,9 @@ curl -v \
 # ...
 {
    "meta" : {
-      "curr" : "/api/v1/issues?parentId=66dc122e1c3a2a7437441731&perPage=100&page=1",
-      "first" : "/api/v1/issues?parentId=66dc122e1c3a2a7437441731&perPage=100&page=1",
-      "last" : "/api/v1/issues?parentId=66dc122e1c3a2a7437441731&perPage=100&page=1",
+      "curr" : "/api/v1/issues?parentId=66dd7ea5e7c673746905ff2a&perPage=100&page=1",
+      "first" : "/api/v1/issues?parentId=66dd7ea5e7c673746905ff2a&perPage=100&page=1",
+      "last" : "/api/v1/issues?parentId=66dd7ea5e7c673746905ff2a&perPage=100&page=1",
       "next" : null,
       "prev" : null,
       "total" : 1
@@ -488,11 +488,11 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66dc125d1c3a2a7437441737",
-         "createdAt" : "2024-09-07T08:44:13.781Z",
+         "_id" : "66dd7ebce7c673746905ff32",
+         "createdAt" : "2024-09-08T10:38:52.671Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66dc122e1c3a2a7437441731",
+         "parentId" : "66dd7ea5e7c673746905ff2a",
          "status" : "1 = backlog"
       }
    ]
@@ -520,8 +520,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66dc11fd1c3a2a743744172f",
-         "createdAt" : "2024-09-07T08:42:37.374Z",
+         "_id" : "66dd7e58e7c673746905ff27",
+         "createdAt" : "2024-09-08T10:37:12.447Z",
          "deadline" : "2024-09-08T21:08:36.367Z",
          "description" : "backend",
          "parentId" : null,
@@ -529,8 +529,8 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66dc122e1c3a2a7437441731",
-         "createdAt" : "2024-09-07T08:43:26.920Z",
+         "_id" : "66dd7ea5e7c673746905ff2a",
+         "createdAt" : "2024-09-08T10:38:29.616Z",
          "deadline" : "2024-09-15T21:08:36.367Z",
          "description" : "frontend",
          "parentId" : null,
@@ -573,8 +573,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66dc122e1c3a2a7437441731",
-         "createdAt" : "2024-09-07T08:43:26.920Z",
+         "_id" : "66dd7ea5e7c673746905ff2a",
+         "createdAt" : "2024-09-08T10:38:29.616Z",
          "deadline" : "2024-09-15T21:08:36.367Z",
          "description" : "frontend",
          "parentId" : null,
@@ -582,20 +582,20 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66dc125d1c3a2a7437441737",
-         "createdAt" : "2024-09-07T08:44:13.781Z",
+         "_id" : "66dd7ebce7c673746905ff32",
+         "createdAt" : "2024-09-08T10:38:52.671Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66dc122e1c3a2a7437441731",
+         "parentId" : "66dd7ea5e7c673746905ff2a",
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66dc12711c3a2a743744173a",
-         "createdAt" : "2024-09-07T08:44:33.757Z",
+         "_id" : "66dd7ec4e7c673746905ff36",
+         "createdAt" : "2024-09-08T10:39:00.513Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "parentId" : "66dc11fd1c3a2a743744172f",
+         "parentId" : "66dd7e58e7c673746905ff27",
          "status" : "2 = selected"
       }
    ]
@@ -622,27 +622,27 @@ curl -v \
    },
    "resources" : [
       {
-         "_id" : "66dc11fd1c3a2a743744172f",
+         "_id" : "66dd7e58e7c673746905ff27",
          "description" : "backend",
          "status" : "3 = in progress"
       },
       {
-         "_id" : "66dc122e1c3a2a7437441731",
+         "_id" : "66dd7ea5e7c673746905ff2a",
          "description" : "frontend",
          "status" : "1 = backlog"
       },
       {
-         "_id" : "66dc12441c3a2a7437441734",
+         "_id" : "66dd7eb5e7c673746905ff2e",
          "description" : "convert the `epic` field to a `parentId` field",
          "status" : "3 = in progress"
       },
       {
-         "_id" : "66dc125d1c3a2a7437441737",
+         "_id" : "66dd7ebce7c673746905ff32",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
          "status" : "1 = backlog"
       },
       {
-         "_id" : "66dc12711c3a2a743744173a",
+         "_id" : "66dd7ec4e7c673746905ff36",
          "description" : "containerize the backend",
          "status" : "2 = selected"
       }
@@ -671,8 +671,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66dc11fd1c3a2a743744172f",
-         "createdAt" : "2024-09-07T08:42:37.374Z",
+         "_id" : "66dd7e58e7c673746905ff27",
+         "createdAt" : "2024-09-08T10:37:12.447Z",
          "deadline" : "2024-09-08T21:08:36.367Z",
          "description" : "backend",
          "parentId" : null,
@@ -680,26 +680,26 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66dc12441c3a2a7437441734",
-         "createdAt" : "2024-09-07T08:43:48.263Z",
+         "_id" : "66dd7eb5e7c673746905ff2e",
+         "createdAt" : "2024-09-08T10:38:45.259Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
-         "parentId" : "66dc11fd1c3a2a743744172f",
+         "parentId" : "66dd7e58e7c673746905ff27",
          "status" : "3 = in progress"
       },
       {
          "__v" : 0,
-         "_id" : "66dc12711c3a2a743744173a",
-         "createdAt" : "2024-09-07T08:44:33.757Z",
+         "_id" : "66dd7ec4e7c673746905ff36",
+         "createdAt" : "2024-09-08T10:39:00.513Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "parentId" : "66dc11fd1c3a2a743744172f",
+         "parentId" : "66dd7e58e7c673746905ff27",
          "status" : "2 = selected"
       },
       {
          "__v" : 0,
-         "_id" : "66dc122e1c3a2a7437441731",
-         "createdAt" : "2024-09-07T08:43:26.920Z",
+         "_id" : "66dd7ea5e7c673746905ff2a",
+         "createdAt" : "2024-09-08T10:38:29.616Z",
          "deadline" : "2024-09-15T21:08:36.367Z",
          "description" : "frontend",
          "parentId" : null,
@@ -707,11 +707,11 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66dc125d1c3a2a7437441737",
-         "createdAt" : "2024-09-07T08:44:13.781Z",
+         "_id" : "66dd7ebce7c673746905ff32",
+         "createdAt" : "2024-09-08T10:38:52.671Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66dc122e1c3a2a7437441731",
+         "parentId" : "66dd7ea5e7c673746905ff2a",
          "status" : "1 = backlog"
       }
    ]
@@ -739,8 +739,8 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66dc122e1c3a2a7437441731",
-         "createdAt" : "2024-09-07T08:43:26.920Z",
+         "_id" : "66dd7ea5e7c673746905ff2a",
+         "createdAt" : "2024-09-08T10:38:29.616Z",
          "deadline" : "2024-09-15T21:08:36.367Z",
          "description" : "frontend",
          "parentId" : null,
@@ -748,26 +748,26 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66dc125d1c3a2a7437441737",
-         "createdAt" : "2024-09-07T08:44:13.781Z",
+         "_id" : "66dd7ebce7c673746905ff32",
+         "createdAt" : "2024-09-08T10:38:52.671Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66dc122e1c3a2a7437441731",
+         "parentId" : "66dd7ea5e7c673746905ff2a",
          "status" : "1 = backlog"
       },
       {
          "__v" : 0,
-         "_id" : "66dc12711c3a2a743744173a",
-         "createdAt" : "2024-09-07T08:44:33.757Z",
+         "_id" : "66dd7ec4e7c673746905ff36",
+         "createdAt" : "2024-09-08T10:39:00.513Z",
          "deadline" : "2024-08-31T23:08:36.367Z",
          "description" : "containerize the backend",
-         "parentId" : "66dc11fd1c3a2a743744172f",
+         "parentId" : "66dd7e58e7c673746905ff27",
          "status" : "2 = selected"
       },
       {
          "__v" : 0,
-         "_id" : "66dc11fd1c3a2a743744172f",
-         "createdAt" : "2024-09-07T08:42:37.374Z",
+         "_id" : "66dd7e58e7c673746905ff27",
+         "createdAt" : "2024-09-08T10:37:12.447Z",
          "deadline" : "2024-09-08T21:08:36.367Z",
          "description" : "backend",
          "parentId" : null,
@@ -775,11 +775,11 @@ curl -v \
       },
       {
          "__v" : 0,
-         "_id" : "66dc12441c3a2a7437441734",
-         "createdAt" : "2024-09-07T08:43:48.263Z",
+         "_id" : "66dd7eb5e7c673746905ff2e",
+         "createdAt" : "2024-09-08T10:38:45.259Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
-         "parentId" : "66dc11fd1c3a2a743744172f",
+         "parentId" : "66dd7e58e7c673746905ff27",
          "status" : "3 = in progress"
       }
    ]
@@ -807,20 +807,20 @@ curl -v \
    "resources" : [
       {
          "__v" : 0,
-         "_id" : "66dc12441c3a2a7437441734",
-         "createdAt" : "2024-09-07T08:43:48.263Z",
+         "_id" : "66dd7eb5e7c673746905ff2e",
+         "createdAt" : "2024-09-08T10:38:45.259Z",
          "deadline" : "2024-08-31T21:08:36.367Z",
          "description" : "convert the `epic` field to a `parentId` field",
-         "parentId" : "66dc11fd1c3a2a743744172f",
+         "parentId" : "66dd7e58e7c673746905ff27",
          "status" : "3 = in progress"
       },
       {
          "__v" : 0,
-         "_id" : "66dc125d1c3a2a7437441737",
-         "createdAt" : "2024-09-07T08:44:13.781Z",
+         "_id" : "66dd7ebce7c673746905ff32",
+         "createdAt" : "2024-09-08T10:38:52.671Z",
          "deadline" : "2024-08-31T22:08:36.367Z",
          "description" : "build a client (hopefully, a CLI tool combined with `jq`)",
-         "parentId" : "66dc122e1c3a2a7437441731",
+         "parentId" : "66dd7ea5e7c673746905ff2a",
          "status" : "1 = backlog"
       }
    ]
@@ -870,11 +870,11 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66dc12711c3a2a743744173a",
-   "createdAt" : "2024-09-07T08:44:33.757Z",
+   "_id" : "66dd7ec4e7c673746905ff36",
+   "createdAt" : "2024-09-08T10:39:00.513Z",
    "deadline" : "2024-08-31T23:08:36.367Z",
    "description" : "containerize the backend",
-   "parentId" : "66dc11fd1c3a2a743744172f",
+   "parentId" : "66dd7e58e7c673746905ff27",
    "status" : "2 = selected"
 }
 ```
@@ -929,11 +929,11 @@ curl -v \
 # ...
 {
    "__v" : 0,
-   "_id" : "66dc12711c3a2a743744173a",
-   "createdAt" : "2024-09-07T08:44:33.757Z",
+   "_id" : "66dd7ec4e7c673746905ff36",
+   "createdAt" : "2024-09-08T10:39:00.513Z",
    "deadline" : "2024-08-31T23:08:36.367Z",
    "description" : "containerize the backend",
-   "parentId" : "66dc11fd1c3a2a743744172f",
+   "parentId" : "66dd7e58e7c673746905ff27",
    "status" : "3 = in progress"
 }
 ```

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -59,8 +59,12 @@ describe('POST /api/v1/tokens', () => {
       // Arrange.
       process.env = {
         ...PROCESS_ENV_ORIGINAL,
+        BACKEND_SECRET_KEY:
+          'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
+        BACKEND_USER_ID: '17',
         BACKEND_USERNAME: 'test-username',
         BACKEND_PASSWORD: 'test-password',
+        BACKEND_JWT_EXPIRES_IN: '17m',
       };
 
       // Act.
@@ -69,9 +73,9 @@ describe('POST /api/v1/tokens', () => {
         .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
       // Assert.
-      expect(response.status).toEqual(503);
+      expect(response.status).toEqual(200);
       expect(response.body).toEqual({
-        accessToken: 'accessToken',
+        accessToken: expect.anything(),
       });
     }
   );

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -37,7 +37,6 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  jest.resetModules();
   await mongoose.connection.db.dropDatabase();
 });
 
@@ -47,6 +46,16 @@ afterAll(async () => {
 });
 
 describe('POST /api/v1/tokens', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
   test(
     'if the client sends a correct set of Basic Auth credentials,' +
       ' should return 200',

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const request = require('supertest');
 
 const app = require('../src/app');
-const { Issue } = require('../src/models');
+const { RevokedToken, Issue } = require('../src/models');
 const {
   corruptIdOfMongooseObject,
   decodeQueryStringWithinUrl,
@@ -87,15 +87,22 @@ describe('DELETE /api/v1/tokens', () => {
       .post('/api/v1/tokens')
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
+    const accessToken = response1.body.accessToken;
+
     // Act.
     const response2 = await request(app)
       .delete('/api/v1/tokens')
-      .set('Authorization', 'Bearer ' + response1.body.accessToken);
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response2.status).toEqual(204);
     expect(response2.headers['content-length']).toEqual('0');
     expect(response2.body).toEqual({});
+
+    const revokedToken = await RevokedToken.find({
+      accessToken,
+    });
+    expect(revokedToken.length).toEqual(1);
   });
 });
 

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -82,11 +82,35 @@ describe('POST /api/v1/tokens', () => {
 });
 
 describe('POST /api/v1/issues', () => {
+  const PROCESS_ENV_ORIGINAL = process.env;
+
+  afterEach(() => {
+    process.env = PROCESS_ENV_ORIGINAL;
+  });
+
   test('if "status" is missing, should return 400', async () => {
+    // Arrange.
+    process.env = {
+      ...PROCESS_ENV_ORIGINAL,
+      BACKEND_SECRET_KEY:
+        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
+      BACKEND_USER_ID: '17',
+      BACKEND_USERNAME: 'test-username',
+      BACKEND_PASSWORD: 'test-password',
+      BACKEND_JWT_EXPIRES_IN: '17m',
+    };
+
+    const response0 = await request(app)
+      .post('/api/v1/tokens')
+      .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
+
     // Act.
-    const response = await request(app).post('/api/v1/issues').send({
-      description: 'containerize the backend',
-    });
+    const response = await request(app)
+      .post('/api/v1/issues')
+      .set('Authorization', 'Bearer ' + response0.body.accessToken)
+      .send({
+        description: 'containerize the backend',
+      });
 
     // Assert.
     expect(response.status).toEqual(400);

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -80,6 +80,25 @@ describe('POST /api/v1/tokens', () => {
   );
 });
 
+describe('DELETE /api/v1/tokens', () => {
+  test('if a client sends a valid access token, should return 204', async () => {
+    // Arrange.
+    const response1 = await request(app)
+      .post('/api/v1/tokens')
+      .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
+
+    // Act.
+    const response2 = await request(app)
+      .delete('/api/v1/tokens')
+      .set('Authorization', 'Bearer ' + response1.body.accessToken);
+
+    // Assert.
+    expect(response2.status).toEqual(204);
+    expect(response2.headers['content-length']).toEqual('0');
+    expect(response2.body).toEqual({});
+  });
+});
+
 describe('POST /api/v1/issues', () => {
   let accessToken;
 
@@ -101,6 +120,7 @@ describe('POST /api/v1/issues', () => {
       });
 
     // Assert.
+    console.log('response.body = ', response.body);
     expect(response.status).toEqual(400);
     expect(response.body).toEqual({
       message: 'Unable to create a new issue.',

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -270,6 +270,10 @@ describe('GET /api/v1/issues', () => {
     accessToken = response.body.accessToken;
   });
 
+  afterEach(() => {
+    process.env = PROCESS_ENV_ORIGINAL;
+  });
+
   test(
     'if there are no Issue resources in the MongoDB server,' +
       ' should return 200 and an empty list',
@@ -691,6 +695,10 @@ describe('GET /api/v1/issues/:id', () => {
     accessToken = response.body.accessToken;
   });
 
+  afterEach(() => {
+    process.env = PROCESS_ENV_ORIGINAL;
+  });
+
   test('if an invalid ID is provided, should return 400', async () => {
     // Act.
     const response = await request(app)
@@ -753,6 +761,10 @@ describe('PUT /api/v1/issues/:id', () => {
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
     accessToken = response.body.accessToken;
+  });
+
+  afterEach(() => {
+    process.env = PROCESS_ENV_ORIGINAL;
   });
 
   test('if an invalid ID is provided, should return 400', async () => {
@@ -854,6 +866,10 @@ describe('DELETE /api/v1/issues/:id', () => {
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
     accessToken = response.body.accessToken;
+  });
+
+  afterEach(() => {
+    process.env = PROCESS_ENV_ORIGINAL;
   });
 
   test('if an invalid ID is provided, should return 400', async () => {

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -37,12 +37,36 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
+  jest.resetModules();
   await mongoose.connection.db.dropDatabase();
 });
 
 afterAll(async () => {
   await mongoose.disconnect();
   await mongoMemoryServer.stop();
+});
+
+describe('POST /api/v1/tokens', () => {
+  test(
+    'if the client sends a correct set of Basic Auth credentials,' +
+      ' should return 200',
+    async () => {
+      // Arrange.
+      process.env.BACKEND_USERNAME = 'test-username';
+      process.env.BACKEND_PASSWORD = 'test-password';
+
+      // Act.
+      const response = await request(app)
+        .post('/api/v1/tokens')
+        .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
+
+      // Assert.
+      expect(response.status).toEqual(503);
+      expect(response.body).toEqual({
+        accessToken: 'accessToken',
+      });
+    }
+  );
 });
 
 describe('POST /api/v1/issues', () => {

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -127,7 +127,6 @@ describe('POST /api/v1/issues', () => {
       });
 
     // Assert.
-    console.log('response.body = ', response.body);
     expect(response.status).toEqual(400);
     expect(response.body).toEqual({
       message: 'Unable to create a new issue.',

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -36,8 +36,24 @@ beforeAll(async () => {
   await mongoose.connect(uri);
 });
 
+const PROCESS_ENV_ORIGINAL = process.env;
+
 beforeEach(async () => {
   await mongoose.connection.db.dropDatabase();
+
+  process.env = {
+    ...PROCESS_ENV_ORIGINAL,
+    BACKEND_SECRET_KEY:
+      'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
+    BACKEND_USER_ID: '17',
+    BACKEND_USERNAME: 'test-username',
+    BACKEND_PASSWORD: 'test-password',
+    BACKEND_JWT_EXPIRES_IN: '17m',
+  };
+});
+
+afterEach(() => {
+  process.env = PROCESS_ENV_ORIGINAL;
 });
 
 afterAll(async () => {
@@ -46,27 +62,10 @@ afterAll(async () => {
 });
 
 describe('POST /api/v1/tokens', () => {
-  const PROCESS_ENV_ORIGINAL = process.env;
-
-  afterEach(() => {
-    process.env = PROCESS_ENV_ORIGINAL;
-  });
-
   test(
     'if a client sends a correct set of Basic Auth credentials,' +
       ' should return 200',
     async () => {
-      // Arrange.
-      process.env = {
-        ...PROCESS_ENV_ORIGINAL,
-        BACKEND_SECRET_KEY:
-          'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
-        BACKEND_USER_ID: '17',
-        BACKEND_USERNAME: 'test-username',
-        BACKEND_PASSWORD: 'test-password',
-        BACKEND_JWT_EXPIRES_IN: '17m',
-      };
-
       // Act.
       const response = await request(app)
         .post('/api/v1/tokens')
@@ -82,30 +81,14 @@ describe('POST /api/v1/tokens', () => {
 });
 
 describe('POST /api/v1/issues', () => {
-  const PROCESS_ENV_ORIGINAL = process.env;
-
   let accessToken;
 
   beforeEach(async () => {
-    process.env = {
-      ...PROCESS_ENV_ORIGINAL,
-      BACKEND_SECRET_KEY:
-        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
-      BACKEND_USER_ID: '17',
-      BACKEND_USERNAME: 'test-username',
-      BACKEND_PASSWORD: 'test-password',
-      BACKEND_JWT_EXPIRES_IN: '17m',
-    };
-
     const response = await request(app)
       .post('/api/v1/tokens')
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
     accessToken = response.body.accessToken;
-  });
-
-  afterEach(() => {
-    process.env = PROCESS_ENV_ORIGINAL;
   });
 
   test('if "status" is missing, should return 400', async () => {
@@ -248,30 +231,14 @@ describe('POST /api/v1/issues', () => {
 });
 
 describe('GET /api/v1/issues', () => {
-  const PROCESS_ENV_ORIGINAL = process.env;
-
   let accessToken;
 
   beforeEach(async () => {
-    process.env = {
-      ...PROCESS_ENV_ORIGINAL,
-      BACKEND_SECRET_KEY:
-        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
-      BACKEND_USER_ID: '17',
-      BACKEND_USERNAME: 'test-username',
-      BACKEND_PASSWORD: 'test-password',
-      BACKEND_JWT_EXPIRES_IN: '17m',
-    };
-
     const response = await request(app)
       .post('/api/v1/tokens')
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
     accessToken = response.body.accessToken;
-  });
-
-  afterEach(() => {
-    process.env = PROCESS_ENV_ORIGINAL;
   });
 
   test(
@@ -673,30 +640,14 @@ describe('GET /api/v1/issues', () => {
 });
 
 describe('GET /api/v1/issues/:id', () => {
-  const PROCESS_ENV_ORIGINAL = process.env;
-
   let accessToken;
 
   beforeEach(async () => {
-    process.env = {
-      ...PROCESS_ENV_ORIGINAL,
-      BACKEND_SECRET_KEY:
-        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
-      BACKEND_USER_ID: '17',
-      BACKEND_USERNAME: 'test-username',
-      BACKEND_PASSWORD: 'test-password',
-      BACKEND_JWT_EXPIRES_IN: '17m',
-    };
-
     const response = await request(app)
       .post('/api/v1/tokens')
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
     accessToken = response.body.accessToken;
-  });
-
-  afterEach(() => {
-    process.env = PROCESS_ENV_ORIGINAL;
   });
 
   test('if an invalid ID is provided, should return 400', async () => {
@@ -741,30 +692,14 @@ describe('GET /api/v1/issues/:id', () => {
 });
 
 describe('PUT /api/v1/issues/:id', () => {
-  const PROCESS_ENV_ORIGINAL = process.env;
-
   let accessToken;
 
   beforeEach(async () => {
-    process.env = {
-      ...PROCESS_ENV_ORIGINAL,
-      BACKEND_SECRET_KEY:
-        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
-      BACKEND_USER_ID: '17',
-      BACKEND_USERNAME: 'test-username',
-      BACKEND_PASSWORD: 'test-password',
-      BACKEND_JWT_EXPIRES_IN: '17m',
-    };
-
     const response = await request(app)
       .post('/api/v1/tokens')
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
     accessToken = response.body.accessToken;
-  });
-
-  afterEach(() => {
-    process.env = PROCESS_ENV_ORIGINAL;
   });
 
   test('if an invalid ID is provided, should return 400', async () => {
@@ -846,30 +781,14 @@ describe('PUT /api/v1/issues/:id', () => {
 });
 
 describe('DELETE /api/v1/issues/:id', () => {
-  const PROCESS_ENV_ORIGINAL = process.env;
-
   let accessToken;
 
   beforeEach(async () => {
-    process.env = {
-      ...PROCESS_ENV_ORIGINAL,
-      BACKEND_SECRET_KEY:
-        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
-      BACKEND_USER_ID: '17',
-      BACKEND_USERNAME: 'test-username',
-      BACKEND_PASSWORD: 'test-password',
-      BACKEND_JWT_EXPIRES_IN: '17m',
-    };
-
     const response = await request(app)
       .post('/api/v1/tokens')
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
     accessToken = response.body.accessToken;
-  });
-
-  afterEach(() => {
-    process.env = PROCESS_ENV_ORIGINAL;
   });
 
   test('if an invalid ID is provided, should return 400', async () => {

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const request = require('supertest');
 
 const app = require('../src/app');
-const Issue = require('../src/models');
+const { Issue } = require('../src/models');
 const {
   corruptIdOfMongooseObject,
   decodeQueryStringWithinUrl,

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -248,12 +248,36 @@ describe('POST /api/v1/issues', () => {
 });
 
 describe('GET /api/v1/issues', () => {
+  const PROCESS_ENV_ORIGINAL = process.env;
+
+  let accessToken;
+
+  beforeEach(async () => {
+    process.env = {
+      ...PROCESS_ENV_ORIGINAL,
+      BACKEND_SECRET_KEY:
+        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
+      BACKEND_USER_ID: '17',
+      BACKEND_USERNAME: 'test-username',
+      BACKEND_PASSWORD: 'test-password',
+      BACKEND_JWT_EXPIRES_IN: '17m',
+    };
+
+    const response = await request(app)
+      .post('/api/v1/tokens')
+      .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
+
+    accessToken = response.body.accessToken;
+  });
+
   test(
     'if there are no Issue resources in the MongoDB server,' +
       ' should return 200 and an empty list',
     async () => {
       // Act.
-      const response = await request(app).get('/api/v1/issues');
+      const response = await request(app)
+        .get('/api/v1/issues')
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response.status).toEqual(200);
@@ -290,7 +314,9 @@ describe('GET /api/v1/issues', () => {
       });
 
       // Act.
-      const response = await request(app).get('/api/v1/issues');
+      const response = await request(app)
+        .get('/api/v1/issues')
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response.status).toEqual(200);
@@ -364,9 +390,9 @@ describe('GET /api/v1/issues', () => {
       });
 
       // Act.
-      const response1 = await request(app).get(
-        `/api/v1/issues?parentId=${issueEpic1Id}`
-      );
+      const response1 = await request(app)
+        .get(`/api/v1/issues?parentId=${issueEpic1Id}`)
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response1.status).toEqual(200);
@@ -403,7 +429,9 @@ describe('GET /api/v1/issues', () => {
       });
 
       // Act.
-      const response2 = await request(app).get('/api/v1/issues?parentId=null');
+      const response2 = await request(app)
+        .get('/api/v1/issues?parentId=null')
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response2.status).toEqual(200);
@@ -441,7 +469,9 @@ describe('GET /api/v1/issues', () => {
       expect(response2.body).toEqual(expectedBodyOfResponse2);
 
       // Act.
-      const response3 = await request(app).get('/api/v1/issues?parentId=');
+      const response3 = await request(app)
+        .get('/api/v1/issues?parentId=')
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response3.status).toEqual(200);
@@ -469,9 +499,9 @@ describe('GET /api/v1/issues', () => {
       });
 
       // Act.
-      const response = await request(app).get(
-        '/api/v1/issues?select=status,description'
-      );
+      const response = await request(app)
+        .get('/api/v1/issues?select=status,description')
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response.status).toEqual(200);
@@ -525,7 +555,9 @@ describe('GET /api/v1/issues', () => {
       });
 
       // Act. (Request a sorting in descending order.)
-      const response1 = await request(app).get('/api/v1/issues?sort=-status');
+      const response1 = await request(app)
+        .get('/api/v1/issues?sort=-status')
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response1.status).toEqual(200);
@@ -566,7 +598,9 @@ describe('GET /api/v1/issues', () => {
       });
 
       // Act. (Request a sorting in ascending order.)
-      const response2 = await request(app).get('/api/v1/issues?sort=status');
+      const response2 = await request(app)
+        .get('/api/v1/issues?sort=status')
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response2.status).toEqual(200);
@@ -602,9 +636,9 @@ describe('GET /api/v1/issues', () => {
       }
 
       // Act.
-      const response = await request(app).get(
-        '/api/v1/issues?perPage=1&page=3'
-      );
+      const response = await request(app)
+        .get('/api/v1/issues?perPage=1&page=3')
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response.status).toEqual(200);
@@ -635,9 +669,33 @@ describe('GET /api/v1/issues', () => {
 });
 
 describe('GET /api/v1/issues/:id', () => {
+  const PROCESS_ENV_ORIGINAL = process.env;
+
+  let accessToken;
+
+  beforeEach(async () => {
+    process.env = {
+      ...PROCESS_ENV_ORIGINAL,
+      BACKEND_SECRET_KEY:
+        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
+      BACKEND_USER_ID: '17',
+      BACKEND_USERNAME: 'test-username',
+      BACKEND_PASSWORD: 'test-password',
+      BACKEND_JWT_EXPIRES_IN: '17m',
+    };
+
+    const response = await request(app)
+      .post('/api/v1/tokens')
+      .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
+
+    accessToken = response.body.accessToken;
+  });
+
   test('if an invalid ID is provided, should return 400', async () => {
     // Act.
-    const response = await request(app).get('/api/v1/issues/17');
+    const response = await request(app)
+      .get('/api/v1/issues/17')
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response.status).toEqual(400);
@@ -656,7 +714,9 @@ describe('GET /api/v1/issues/:id', () => {
     });
 
     // Act.
-    const response = await request(app).get(`/api/v1/issues/${issue._id}`);
+    const response = await request(app)
+      .get(`/api/v1/issues/${issue._id}`)
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response.status).toEqual(200);
@@ -673,6 +733,28 @@ describe('GET /api/v1/issues/:id', () => {
 });
 
 describe('PUT /api/v1/issues/:id', () => {
+  const PROCESS_ENV_ORIGINAL = process.env;
+
+  let accessToken;
+
+  beforeEach(async () => {
+    process.env = {
+      ...PROCESS_ENV_ORIGINAL,
+      BACKEND_SECRET_KEY:
+        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
+      BACKEND_USER_ID: '17',
+      BACKEND_USERNAME: 'test-username',
+      BACKEND_PASSWORD: 'test-password',
+      BACKEND_JWT_EXPIRES_IN: '17m',
+    };
+
+    const response = await request(app)
+      .post('/api/v1/tokens')
+      .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
+
+    accessToken = response.body.accessToken;
+  });
+
   test('if an invalid ID is provided, should return 400', async () => {
     // Arrange.
     const issue = await Issue.create({
@@ -685,7 +767,9 @@ describe('PUT /api/v1/issues/:id', () => {
     const invalidId = issueId.slice(0, issueId.length - 1);
 
     // Act.
-    const response = await request(app).put(`/api/v1/issues/${invalidId}`);
+    const response = await request(app)
+      .put(`/api/v1/issues/${invalidId}`)
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response.status).toEqual(400);
@@ -705,7 +789,9 @@ describe('PUT /api/v1/issues/:id', () => {
     const nonexistentId = corruptIdOfMongooseObject(issue);
 
     // Act.
-    const response = await request(app).put(`/api/v1/issues/${nonexistentId}`);
+    const response = await request(app)
+      .put(`/api/v1/issues/${nonexistentId}`)
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response.status).toEqual(404);
@@ -725,10 +811,13 @@ describe('PUT /api/v1/issues/:id', () => {
     const issueId = issue._id.toString();
 
     // Act.
-    const response = await request(app).put(`/api/v1/issues/${issueId}`).send({
-      status: '2 = selected',
-      description: 'generate code coverage reports in HTML format',
-    });
+    const response = await request(app)
+      .put(`/api/v1/issues/${issueId}`)
+      .send({
+        status: '2 = selected',
+        description: 'generate code coverage reports in HTML format',
+      })
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response.status).toEqual(200);
@@ -745,6 +834,28 @@ describe('PUT /api/v1/issues/:id', () => {
 });
 
 describe('DELETE /api/v1/issues/:id', () => {
+  const PROCESS_ENV_ORIGINAL = process.env;
+
+  let accessToken;
+
+  beforeEach(async () => {
+    process.env = {
+      ...PROCESS_ENV_ORIGINAL,
+      BACKEND_SECRET_KEY:
+        'this-must-be-very-secure-and-must-not-be-shared-with-anyone-else',
+      BACKEND_USER_ID: '17',
+      BACKEND_USERNAME: 'test-username',
+      BACKEND_PASSWORD: 'test-password',
+      BACKEND_JWT_EXPIRES_IN: '17m',
+    };
+
+    const response = await request(app)
+      .post('/api/v1/tokens')
+      .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
+
+    accessToken = response.body.accessToken;
+  });
+
   test('if an invalid ID is provided, should return 400', async () => {
     // Arrange.
     const issue = await Issue.create({
@@ -757,7 +868,9 @@ describe('DELETE /api/v1/issues/:id', () => {
     const invalidId = issueId.slice(0, issueId.length - 1);
 
     // Act.
-    response = await request(app).delete(`/api/v1/issues/${invalidId}`);
+    response = await request(app)
+      .delete(`/api/v1/issues/${invalidId}`)
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response.status).toEqual(400);
@@ -777,9 +890,9 @@ describe('DELETE /api/v1/issues/:id', () => {
     const nonexistentId = corruptIdOfMongooseObject(issue);
 
     // Act.
-    const response = await request(app).delete(
-      `/api/v1/issues/${nonexistentId}`
-    );
+    const response = await request(app)
+      .delete(`/api/v1/issues/${nonexistentId}`)
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response.status).toEqual(404);
@@ -812,9 +925,9 @@ describe('DELETE /api/v1/issues/:id', () => {
       });
 
       // Act.
-      const response = await request(app).delete(
-        `/api/v1/issues/${issueEpic1Id}`
-      );
+      const response = await request(app)
+        .delete(`/api/v1/issues/${issueEpic1Id}`)
+        .set('Authorization', 'Bearer ' + accessToken);
 
       // Assert.
       expect(response.status).toEqual(400);
@@ -841,7 +954,9 @@ describe('DELETE /api/v1/issues/:id', () => {
     const issueId = issue._id.toString();
 
     // Act.
-    const response = await request(app).delete(`/api/v1/issues/${issueId}`);
+    const response = await request(app)
+      .delete(`/api/v1/issues/${issueId}`)
+      .set('Authorization', 'Bearer ' + accessToken);
 
     // Assert.
     expect(response.status).toEqual(204);

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -46,23 +46,22 @@ afterAll(async () => {
 });
 
 describe('POST /api/v1/tokens', () => {
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    jest.resetModules();
-  });
+  const PROCESS_ENV_ORIGINAL = process.env;
 
   afterEach(() => {
-    process.env = originalEnv;
+    process.env = PROCESS_ENV_ORIGINAL;
   });
 
   test(
-    'if the client sends a correct set of Basic Auth credentials,' +
+    'if a client sends a correct set of Basic Auth credentials,' +
       ' should return 200',
     async () => {
       // Arrange.
-      process.env.BACKEND_USERNAME = 'test-username';
-      process.env.BACKEND_PASSWORD = 'test-password';
+      process.env = {
+        ...PROCESS_ENV_ORIGINAL,
+        BACKEND_USERNAME: 'test-username',
+        BACKEND_PASSWORD: 'test-password',
+      };
 
       // Act.
       const response = await request(app)

--- a/__test__/app.test.js
+++ b/__test__/app.test.js
@@ -84,12 +84,9 @@ describe('POST /api/v1/tokens', () => {
 describe('POST /api/v1/issues', () => {
   const PROCESS_ENV_ORIGINAL = process.env;
 
-  afterEach(() => {
-    process.env = PROCESS_ENV_ORIGINAL;
-  });
+  let accessToken;
 
-  test('if "status" is missing, should return 400', async () => {
-    // Arrange.
+  beforeEach(async () => {
     process.env = {
       ...PROCESS_ENV_ORIGINAL,
       BACKEND_SECRET_KEY:
@@ -100,14 +97,22 @@ describe('POST /api/v1/issues', () => {
       BACKEND_JWT_EXPIRES_IN: '17m',
     };
 
-    const response0 = await request(app)
+    const response = await request(app)
       .post('/api/v1/tokens')
       .set('Authorization', 'Basic ' + btoa('test-username:test-password'));
 
+    accessToken = response.body.accessToken;
+  });
+
+  afterEach(() => {
+    process.env = PROCESS_ENV_ORIGINAL;
+  });
+
+  test('if "status" is missing, should return 400', async () => {
     // Act.
     const response = await request(app)
       .post('/api/v1/issues')
-      .set('Authorization', 'Bearer ' + response0.body.accessToken)
+      .set('Authorization', 'Bearer ' + accessToken)
       .send({
         description: 'containerize the backend',
       });
@@ -121,9 +126,12 @@ describe('POST /api/v1/issues', () => {
 
   test('if "description" is missing, should return 400', async () => {
     // Act.
-    const response = await request(app).post('/api/v1/issues').send({
-      status: '1 = backlog',
-    });
+    const response = await request(app)
+      .post('/api/v1/issues')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        status: '1 = backlog',
+      });
 
     // Assert.
     expect(response.status).toEqual(400);
@@ -136,6 +144,7 @@ describe('POST /api/v1/issues', () => {
     // Act.
     const response = await request(app)
       .post('/api/v1/issues')
+      .set('Authorization', 'Bearer ' + accessToken)
       .send({
         createdAt: new Date('2024-08-17T09:00:00.000Z'),
         status: '1 = backlog',
@@ -167,6 +176,7 @@ describe('POST /api/v1/issues', () => {
     // Act.
     const response = await request(app)
       .post('/api/v1/issues')
+      .set('Authorization', 'Bearer ' + accessToken)
       .send({
         status: '1 = backlog',
         deadline: new Date('2024-09-02T02:56:42.053Z'),
@@ -190,6 +200,7 @@ describe('POST /api/v1/issues', () => {
     // Act.
     const response = await request(app)
       .post(`/api/v1/issues`)
+      .set('Authorization', 'Bearer ' + accessToken)
       .send({
         status: '1 = backlog',
         deadline: new Date('2024-09-02T02:56:42.053Z'),
@@ -211,6 +222,7 @@ describe('POST /api/v1/issues', () => {
     // Act.
     const response = await request(app)
       .post('/api/v1/issues')
+      .set('Authorization', 'Bearer ' + accessToken)
       .send({
         status: '1 = backlog',
         deadline: new Date('2024-09-02T02:48:26.383Z'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.5.3",
         "morgan": "^1.10.0"
       },
@@ -1651,6 +1652,12 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2123,6 +2130,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -3776,6 +3792,55 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -3824,6 +3889,48 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4832,7 +4939,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.5.3",
     "morgan": "^1.10.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -66,6 +66,43 @@ app.post('/api/v1/tokens', async (req, res) => {
 });
 
 app.post('/api/v1/issues', async (req, res) => {
+  const headerAuth = req.headers.authorization;
+  if (!headerAuth) {
+    res.status(400).json({
+      message: 'Missing "Authorization" header',
+    });
+
+    return;
+  }
+
+  const [type, accessToken] = headerAuth.split(' ');
+  if (type !== 'Bearer') {
+    res.status(400).json({
+      message: '"Authorization" header must specify Bearer Auth',
+    });
+
+    return;
+  }
+
+  let jwtPayload;
+  try {
+    jwtPayload = jwt.verify(accessToken, process.env.BACKEND_SECRET_KEY);
+  } catch (err) {
+    res.status(401).json({
+      message: 'Invalid access token',
+    });
+
+    return;
+  }
+
+  if (jwtPayload.userId !== parseInt(process.env.BACKEND_USER_ID)) {
+    res.status(401).json({
+      message: 'Your user is not allowed to invoke this endpoint',
+    });
+
+    return;
+  }
+
   let newIssue;
 
   if (req.body.parentId) {

--- a/src/app.js
+++ b/src/app.js
@@ -89,7 +89,9 @@ const tokenAuth = async (req, res, next) => {
   // prior to the current request-response cycle.
   let wasRevoked;
   try {
-    const revokedToken = await RevokedToken.findOne({ accessToken });
+    const revokedToken = await RevokedToken.findOne({
+      accessToken,
+    });
     wasRevoked = revokedToken === null ? false : true;
   } catch (err) {
     res.status(500).json({

--- a/src/app.js
+++ b/src/app.js
@@ -135,10 +135,8 @@ const tokenAuth = async (req, res, next) => {
 };
 
 app.delete('/api/v1/tokens', tokenAuth, async (req, res) => {
-  let revokedToken;
-
   try {
-    revokedToken = RevokedToken.create({
+    let revokedToken = RevokedToken.create({
       userId: parseInt(process.env.BACKEND_USER_ID),
       accessToken: req.accessToken,
     });
@@ -151,7 +149,7 @@ app.delete('/api/v1/tokens', tokenAuth, async (req, res) => {
     return;
   }
 
-  res.status('Content-Length', '0');
+  res.set('Content-Length', '0');
   res.status(204).end();
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -65,7 +65,7 @@ app.post('/api/v1/tokens', async (req, res) => {
   });
 });
 
-app.post('/api/v1/issues', async (req, res) => {
+const tokenAuth = async (req, res, next) => {
   const headerAuth = req.headers.authorization;
   if (!headerAuth) {
     res.status(400).json({
@@ -102,6 +102,15 @@ app.post('/api/v1/issues', async (req, res) => {
 
     return;
   }
+
+  req.userId = jwtPayload.userId;
+
+  next();
+};
+
+app.post('/api/v1/issues', tokenAuth, async (req, res) => {
+  console.log('req.userId = ', req.userId);
+  console.log('typeof req.userId = ', typeof req.userId);
 
   let newIssue;
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const morgan = require('morgan');
+const jwt = require('jsonwebtoken');
 const Issue = require('./models');
 const { determinePaginationInfoInitial } = require('./utilities');
 
@@ -47,10 +48,20 @@ app.post('/api/v1/tokens', async (req, res) => {
   }
 
   // TODO: (2024/09/07, 17:10)
-  //      (a) replace 'accessToken' with a real token
-  //      (b) arrange for creation of a 'refreshToken' that gets returned here as well
-  res.status(503).json({
-    accessToken: 'accessToken',
+  //      arrange for creation of a 'refreshToken' that gets returned here as well
+  const payload = {
+    userId: parseInt(process.env.BACKEND_USER_ID),
+  };
+  const options = {
+    expiresIn: process.env.BACKEND_JWT_EXPIRES_IN,
+  };
+  const accessToken = jwt.sign(
+    payload,
+    process.env.BACKEND_SECRET_KEY,
+    options
+  );
+  res.status(200).json({
+    accessToken,
   });
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -156,8 +156,8 @@ app.delete('/api/v1/tokens', tokenAuth, async (req, res) => {
 });
 
 app.post('/api/v1/issues', tokenAuth, async (req, res) => {
-  console.log('req.userId = ', req.userId);
-  console.log('typeof req.userId = ', typeof req.userId);
+  //console.log('req.userId = ', req.userId);
+  //console.log('typeof req.userId = ', typeof req.userId);
 
   let newIssue;
 
@@ -239,9 +239,9 @@ app.get('/api/v1/issues', tokenAuth, async (req, res) => {
     /\b(in|lt|lte|gt|gte)\b/g,
     (match) => `$${match}`
   );
-  console.log('queryStr', queryStr);
+  //console.log('queryStr', queryStr);
   const queryJSON = JSON.parse(queryStr);
-  console.log('queryJSON', queryJSON);
+  //console.log('queryJSON', queryJSON);
 
   // Apply filtering criteria.
   query = Issue.find(queryJSON);

--- a/src/app.js
+++ b/src/app.js
@@ -156,7 +156,7 @@ app.post('/api/v1/issues', tokenAuth, async (req, res) => {
     .json(newIssue);
 });
 
-app.get('/api/v1/issues', async (req, res) => {
+app.get('/api/v1/issues', tokenAuth, async (req, res) => {
   let query;
 
   // Exclude all query parameters,
@@ -309,7 +309,7 @@ app.get('/api/v1/issues', async (req, res) => {
   }
 });
 
-app.get('/api/v1/issues/:id', async (req, res) => {
+app.get('/api/v1/issues/:id', tokenAuth, async (req, res) => {
   let issue;
   const issueId = req.params.id;
   try {
@@ -333,7 +333,7 @@ app.get('/api/v1/issues/:id', async (req, res) => {
   res.status(200).json(issue);
 });
 
-app.put('/api/v1/issues/:id', async (req, res) => {
+app.put('/api/v1/issues/:id', tokenAuth, async (req, res) => {
   let issue;
   const issueId = req.params.id;
   try {
@@ -361,7 +361,7 @@ app.put('/api/v1/issues/:id', async (req, res) => {
   res.status(200).json(issue);
 });
 
-app.delete('/api/v1/issues/:id', async (req, res) => {
+app.delete('/api/v1/issues/:id', tokenAuth, async (req, res) => {
   let issue;
   const issueId = req.params.id;
   try {

--- a/src/app.js
+++ b/src/app.js
@@ -136,7 +136,7 @@ const tokenAuth = async (req, res, next) => {
 
 app.delete('/api/v1/tokens', tokenAuth, async (req, res) => {
   try {
-    let revokedToken = RevokedToken.create({
+    let revokedToken = await RevokedToken.create({
       userId: parseInt(process.env.BACKEND_USER_ID),
       accessToken: req.accessToken,
     });

--- a/src/app.js
+++ b/src/app.js
@@ -84,6 +84,25 @@ const tokenAuth = async (req, res, next) => {
     return;
   }
 
+  let isRevoked;
+  try {
+    const revokedToken = await RevokedToken.findOne({ accessToken });
+    isRevoked = revokedToken === null ? false : true;
+  } catch (err) {
+    res.status(500).json({
+      message: 'Failed to process your HTTP request',
+    });
+
+    return;
+  }
+  if (isRevoked) {
+    res.status(401).json({
+      message: 'Revoked access token',
+    });
+
+    return;
+  }
+
   let jwtPayload;
   try {
     jwtPayload = jwt.verify(accessToken, process.env.BACKEND_SECRET_KEY);

--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,46 @@ if (process.env.NODE_ENV === 'development') {
   app.use(morgan('dev'));
 }
 
+app.post('/api/v1/tokens', async (req, res) => {
+  const headerAuth = req.headers.authorization;
+  if (!headerAuth) {
+    res.status(400).json({
+      message: 'Missing "Authorization" header',
+    });
+
+    return;
+  }
+
+  const [type, authCredsEncoded] = headerAuth.split(' ');
+  if (type !== 'Basic') {
+    res.status(400).json({
+      message: '"Authorization" header must specify Basic Auth',
+    });
+
+    return;
+  }
+
+  const authCredsDecoded = Buffer.from(authCredsEncoded, 'base64').toString();
+  const [username, password] = authCredsDecoded.split(':');
+  if (
+    username !== process.env.BACKEND_USERNAME ||
+    password !== process.env.BACKEND_PASSWORD
+  ) {
+    res.status(401).json({
+      message: 'Incorrect credentials',
+    });
+
+    return;
+  }
+
+  // TODO: (2024/09/07, 17:10)
+  //      (a) replace 'accessToken' with a real token
+  //      (b) arrange for creation of a 'refreshToken' that gets returned here as well
+  res.status(503).json({
+    accessToken: 'accessToken',
+  });
+});
+
 app.post('/api/v1/issues', async (req, res) => {
   let newIssue;
 

--- a/src/models.js
+++ b/src/models.js
@@ -43,4 +43,32 @@ const IssueSchema = new mongoose.Schema({
 
 const Issue = new mongoose.model(NAME_OF_ISSUE_MODEL, IssueSchema);
 
-module.exports = Issue;
+// TODO: (2024/09/08, 09:43)
+//      move the rejected-token-related symbols
+//      to the top of this file
+
+// TODO: (2024/09/08, 00:05)
+//      create a `RevokedToken` model
+//      + utilize it in the `tokenAuth` middleware function
+
+const RevokedTokenSchema = new mongoose.Schema({
+  // TODO: (2024/09/08, 09:42)
+  //      when a `User` model is implemented,
+  //      the following should be changed to a reference to `User._id`
+  userId: {
+    type: Number,
+    required: [true, 'Please specify a value for "userId"'],
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  accessToken: {
+    type: String,
+    required: [true, 'Please specify a value for "accessToken"'],
+  },
+});
+
+const RevokedToken = new mongoose.model('RevokedToken', RevokedTokenSchema);
+
+module.exports = { RevokedToken, Issue };

--- a/src/models.js
+++ b/src/models.js
@@ -1,5 +1,25 @@
 const mongoose = require('mongoose');
 
+const RevokedTokenSchema = new mongoose.Schema({
+  // TODO: (2024/09/08, 09:42)
+  //      when a `User` model is implemented,
+  //      the following should be changed to a reference to `User._id`
+  userId: {
+    type: Number,
+    required: [true, 'Please specify a value for "userId"'],
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  accessToken: {
+    type: String,
+    required: [true, 'Please specify a value for "accessToken"'],
+  },
+});
+
+const RevokedToken = new mongoose.model('RevokedToken', RevokedTokenSchema);
+
 const NAME_OF_ISSUE_MODEL = 'Issue';
 
 const IssueSchema = new mongoose.Schema({
@@ -42,29 +62,5 @@ const IssueSchema = new mongoose.Schema({
 });
 
 const Issue = new mongoose.model(NAME_OF_ISSUE_MODEL, IssueSchema);
-
-// TODO: (2024/09/08, 09:43)
-//      move the rejected-token-related symbols
-//      to the top of this file
-
-const RevokedTokenSchema = new mongoose.Schema({
-  // TODO: (2024/09/08, 09:42)
-  //      when a `User` model is implemented,
-  //      the following should be changed to a reference to `User._id`
-  userId: {
-    type: Number,
-    required: [true, 'Please specify a value for "userId"'],
-  },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-  accessToken: {
-    type: String,
-    required: [true, 'Please specify a value for "accessToken"'],
-  },
-});
-
-const RevokedToken = new mongoose.model('RevokedToken', RevokedTokenSchema);
 
 module.exports = { RevokedToken, Issue };

--- a/src/models.js
+++ b/src/models.js
@@ -2,8 +2,10 @@ const mongoose = require('mongoose');
 
 const RevokedTokenSchema = new mongoose.Schema({
   // TODO: (2024/09/08, 09:42)
-  //      when a `User` model is implemented,
-  //      the following should be changed to a reference to `User._id`
+  //      when a `User` model is implemented:
+  //      (a) the following should be changed to a reference to `User._id`
+  //      (b) more meaningful/comprehensive tests for requests to `/api/v1/tokens`
+  //          should be implemented
   userId: {
     type: Number,
     required: [true, 'Please specify a value for "userId"'],
@@ -12,6 +14,9 @@ const RevokedTokenSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+  // TODO: (2024/09/08, 15:39)
+  //        create a secondary index on this field
+  //        https://mongoosejs.com/docs/guide.html#indexes
   accessToken: {
     type: String,
     required: [true, 'Please specify a value for "accessToken"'],

--- a/src/models.js
+++ b/src/models.js
@@ -47,10 +47,6 @@ const Issue = new mongoose.model(NAME_OF_ISSUE_MODEL, IssueSchema);
 //      move the rejected-token-related symbols
 //      to the top of this file
 
-// TODO: (2024/09/08, 00:05)
-//      create a `RevokedToken` model
-//      + utilize it in the `tokenAuth` middleware function
-
 const RevokedTokenSchema = new mongoose.Schema({
   // TODO: (2024/09/08, 09:42)
   //      when a `User` model is implemented,

--- a/src/server.js
+++ b/src/server.js
@@ -9,11 +9,6 @@ dotenv.config({
 
 const connectToDatabasePromise = connectToDatabase();
 
-console.log();
-console.log(`BACKEND_USERNAME = ${process.env.BACKEND_USERNAME}`);
-console.log(`BACKEND_PASSWORD = ${process.env.BACKEND_PASSWORD}`);
-console.log();
-
 connectToDatabasePromise
   .then(() => {
     const PORT = 5000;

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,11 @@ dotenv.config({
 
 const connectToDatabasePromise = connectToDatabase();
 
+console.log();
+console.log(`BACKEND_USERNAME = ${process.env.BACKEND_USERNAME}`);
+console.log(`BACKEND_PASSWORD = ${process.env.BACKEND_PASSWORD}`);
+console.log();
+
 connectToDatabasePromise
   .then(() => {
     const PORT = 5000;


### PR DESCRIPTION
this pull request implements a minimalistic authentication sub-system

---

it is minimalistic,
because it supports exactly one user
whose **_id_**, **_username_**, and **_password_** must be specified via environment variables;
in other words,
each of the backend application's endpoints is protected via **_Basic Auth_** or **_Bearer Auth_**
and
only the user specified via the environment variables in the `.env` file is authorized to interact with those endpoints;

---

the authentication flow is as follows:

- the only supported user has to issue a `POST /api/v1/tokens` request
  and include an `Authorization` header with his/her **_Basic Auth_** credentials,
  which will generate an HTTP response whose body contains an `accessToken`

- each `accessToken` is a JSON Web Signature Token (aka «JWT»)
  and will expire after a fixed amount of time;
  that amount of time must be specified
  via one of the environment variable within the `.env` file

- in order to issue a request
  to any one of the other endpoints supported by the backend application,
  the user has to include an `Authorization` header (in the **_Bearer Auth_** format) with the `accessToken`

- even before an `accessToken` has expired,
  the user can revoke it
  by issuing a `DELELE /api/v1/tokens` request
  and including an `Authorization` header (in the **_Bearer Auth_** format) with the to-be-revoked `accessToken`